### PR TITLE
Tooling clean out

### DIFF
--- a/caramel/scripts/tool.py
+++ b/caramel/scripts/tool.py
@@ -17,30 +17,57 @@ import concurrent.futures
 def cmdline():
     parser = argparse.ArgumentParser()
     parser.add_argument("inifile")
-    parser.add_argument("--long", help="Generate a long lived cert(1 year)",
-                        action="store_true")
+    parser.add_argument(
+        "--long",
+        help="Generate a long lived cert(1 year)",
+        action="store_true",
+    )
 
-    parser.add_argument("--list", help="List active requests, do nothing else",
-                        action="store_true")
+    parser.add_argument(
+        "--list",
+        help="List active requests, do nothing else",
+        action="store_true",
+    )
 
     exclusives = parser.add_mutually_exclusive_group()
-    exclusives.add_argument("--sign", metavar="id", type=int,
-                            help="Sign the CSR with this id")
-    exclusives.add_argument("--reject", metavar="id", type=int,
-                            help="Reject the CSR with this id")
+    exclusives.add_argument(
+        "--sign", metavar="id", type=int, help="Sign the CSR with this id"
+    )
+    exclusives.add_argument(
+        "--reject",
+        metavar="id",
+        type=int,
+        help="Reject the CSR with this id",
+    )
 
     cleanout = parser.add_mutually_exclusive_group()
-    cleanout.add_argument("--clean", metavar="id", type=int,
-                          help="Remove all older certificates for this CSR")
-    cleanout.add_argument("--wipe", metavar="id", type=int,
-                          help="Wipe all certificates for this CSR")
+    cleanout.add_argument(
+        "--clean",
+        metavar="id",
+        type=int,
+        help="Remove all older certificates for this CSR",
+    )
+    cleanout.add_argument(
+        "--wipe",
+        metavar="id",
+        type=int,
+        help="Wipe all certificates for this CSR",
+    )
 
     bulk = parser.add_mutually_exclusive_group()
-    bulk.add_argument("--refresh", help="Sign all certificates previously "
-                      "signed certificates again.", action="store_true")
+    bulk.add_argument(
+        "--refresh",
+        help=(
+            "Sign all certificates previously " "signed certificates again."
+        ),
+        action="store_true",
+    )
 
-    bulk.add_argument("--cleanall", help="Clean all older certificates.",
-                      action="store_true")
+    bulk.add_argument(
+        "--cleanall",
+        help="Clean all older certificates.",
+        action="store_true",
+    )
 
     args = parser.parse_args()
 
@@ -61,8 +88,9 @@ def print_list():
             not_after = str(cert.not_after)
         else:
             not_after = "----------"
-        output = " ".join((str(csr.id), csr.commonname, csr.sha256sum,
-                           not_after))
+        output = " ".join(
+            (str(csr.id), csr.commonname, csr.sha256sum, not_after)
+        )
         # TODO: Add lifetime of latest (fetched?) cert for the key.
         print(output)
 
@@ -116,11 +144,13 @@ def csr_sign(number, ca, timedelta, backdate):
             cur_lifetime = cert.not_after - cert.not_before
             # Cert hasn't expired, and currently has longer lifetime
             if (cert.not_after > today) and (cur_lifetime > timedelta):
-                msg = ("Currently has a valid certificate with {} lifetime, "
-                       "new certificate would have {} lifetime. \n"
-                       "Clean out existing certificates before shortening "
-                       "lifetime.\n"
-                       "The old certificate is still out there.")
+                msg = (
+                    "Currently has a valid certificate with {} lifetime, "
+                    "new certificate would have {} lifetime. \n"
+                    "Clean out existing certificates before shortening "
+                    "lifetime.\n"
+                    "The old certificate is still out there."
+                )
                 error_out(msg.format(cur_lifetime, timedelta))
 
         cert = models.Certificate.sign(CSR, ca, timedelta, backdate)
@@ -146,10 +176,12 @@ def csr_resign(ca, lifetime_short, lifetime_long, backdate):
             csrlist = models.CSR.refreshable()
         except:
             error_out("No CSR's found")
-        futures = (executor.submit(refresh,
-                                   csr, ca,
-                                   lifetime_short, lifetime_long, backdate)
-                   for csr in csrlist)
+        futures = (
+            executor.submit(
+                refresh, csr, ca, lifetime_short, lifetime_long, backdate
+            )
+            for csr in csrlist
+        )
         for future in concurrent.futures.as_completed(futures):
             try:
                 future.result()
@@ -160,13 +192,13 @@ def csr_resign(ca, lifetime_short, lifetime_long, backdate):
 def main():
     args = cmdline()
     env = bootstrap(args.inifile)
-    settings, closer = env['registry'].settings, env['closer']
-    engine = create_engine(settings['sqlalchemy.url'])
+    settings, closer = env["registry"].settings, env["closer"]
+    engine = create_engine(settings["sqlalchemy.url"])
     models.init_session(engine)
-    settings_backdate = asbool(settings.get('backdate', False))
+    settings_backdate = asbool(settings.get("backdate", False))
 
-    _short = int(settings.get('lifetime.short', 48))
-    _long = int(settings.get('lifetime.long', 7*24))
+    _short = int(settings.get("lifetime.short", 48))
+    _long = int(settings.get("lifetime.long", 7 * 24))
     life_short = calc_lifetime(relativedelta(hours=_short))
     life_long = calc_lifetime(relativedelta(hours=_long))
     del _short, _long
@@ -179,8 +211,10 @@ def main():
     ca = models.SigningCert.from_files(certname, keyname)
 
     if life_short > life_long:
-        error_out("Short lived certs ({0}) shouldn't last longer "
-                  "than long lived certs ({1})".format(life_short, life_long))
+        error_out(
+            "Short lived certs ({0}) shouldn't last longer "
+            "than long lived certs ({1})".format(life_short, life_long)
+        )
     if args.list:
         print_list()
         closer()

--- a/caramel/scripts/tool.py
+++ b/caramel/scripts/tool.py
@@ -115,9 +115,15 @@ def csr_clean(number):
         CSR = models.CSR.query().get(number)
         if not CSR:
             error_out("ID not found")
-        certs = sorted(CSR.certificates, key=lambda cert: cert.id)
+        certs = sorted(CSR.certificates, key=lambda cert: cert.not_after)
         CSR.certificates = [certs[-1]]
         CSR.save()
+
+
+def clean_all():
+    csrlist = models.CSR.refreshable()
+    for csr in csrlist:
+        csr_clean(csr.id)
 
 
 def csr_reject(number):
@@ -174,7 +180,7 @@ def csr_resign(ca, lifetime_short, lifetime_long, backdate):
     with concurrent.futures.ThreadPoolExecutor(max_workers=16) as executor:
         try:
             csrlist = models.CSR.refreshable()
-        except:
+        except Exception:
             error_out("No CSR's found")
         futures = (
             executor.submit(
@@ -230,7 +236,7 @@ def main():
         error_out("Not implemented yet")
 
     if args.cleanall:
-        error_out("Not implemented yet")
+        clean_all()
 
     if args.sign:
         if args.long:


### PR DESCRIPTION
This uses a brute force slowish approach by iterating over CSR id and then
dropping all but the last valid Certificate for each csr.

It can be more efficiently done inside the database, except that the memory
used might cause a slight headache on SQLite.  Running the single query version
took several minutes on SQLite with 150k certificates give or take.