### PR TITLE
CSR: Turn certificates into a dynamic query

### DIFF
--- a/caramel/models.py
+++ b/caramel/models.py
@@ -147,7 +147,7 @@ class CSR(Base):
                                  order_by="AccessLog.when.desc()")
     certificates = _orm.relationship("Certificate", backref="csr",
                                      order_by="Certificate.not_after.desc()",
-                                     lazy="subquery",
+                                     lazy="dynamic",
                                      cascade="all, delete-orphan")
 
     def __init__(self, sha256sum, reqtext):

--- a/caramel/scripts/generate_ca.py
+++ b/caramel/scripts/generate_ca.py
@@ -30,6 +30,7 @@ def _crypto_patch():
     about it."""
     _crypto._lib.ASN1_STRING_set_default_mask_asc(b'utf8only')
 
+
 _crypto_patch()
 
 

--- a/caramel/views.py
+++ b/caramel/views.py
@@ -119,8 +119,8 @@ def cert_fetch(request):
     AccessLog(csr, request.remote_addr).save()
     if csr.rejected:
         raise HTTPForbidden
-    if csr.certificates:
-        cert = csr.certificates[0]
+    cert = csr.certificates.first()
+    if cert:
         if datetime.utcnow() < cert.not_after:
             # XXX: appropriate content-type is ... ?
             return Response(cert.pem,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 requires = [
     "pyramid",
-    "SQLAlchemy",
+    "SQLAlchemy >= 1.1",
     "transaction",
     "pyramid_tm",
     "zope.sqlalchemy",


### PR DESCRIPTION
This prevents automatic loading, by using .certificates as a dynamic query
object, rather than something more.

Since most usecases only require a single item (last valid certificate) we
special case this.

Closes: #50