### PR TITLE
Added multiple arg support for query wrapper

### DIFF
--- a/caramel/models.py
+++ b/caramel/models.py
@@ -100,8 +100,10 @@ class Base(object):
         DBSession.flush()
 
     @classmethod
-    def query(cls):
-        return DBSession.query(cls)
+    def query(cls, *args, **kwargs):
+        if not args:
+            return DBSession.query(cls)
+        return DBSession.query(*args, **kwargs)
 
     @classmethod
     def all(cls):


### PR DESCRIPTION
list_csr_printable uses session.query(*entities, **kwargs) while base.query()
only passed on cls ("self") limiting full use of the underlying method.
To support old behavior a check is made if base.query is passed any additional arguments
and if not then just pass cls to session.query, otherwise pass it will pass on the arguments
leaving out cls.