### PR TITLE
Config file as argument or in env

### DIFF
--- a/caramel/config.py
+++ b/caramel/config.py
@@ -1,0 +1,30 @@
+#! /usr/bin/env python
+# vim: expandtab shiftwidth=4 softtabstop=4 tabstop=17 filetype=python :
+import argparse
+import os
+
+
+def add_inifile_argument(parser, env=os.environ):
+    default_ini = env.get("CARAMEL_INI")
+
+    parser.add_argument(
+        nargs="?",
+        help="Path to a specific .ini-file to use as config",
+        dest="inifile",
+        default=default_ini,
+        type=str,
+        action=check_inifile_path_set,
+    )
+
+
+class check_inifile_path_set(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, values)
+        inifile = getattr(namespace, self.dest, None)
+        if inifile is None:
+            raise ValueError(
+                "ENVIRONMENT VARIABLE 'CARAMEL_INI' IS NOT SET\n"
+                " - Set 'CARAMEL_INI' to the absolute path of the config or"
+                " specify a path in the call like so:\n"
+                "\t caramel_initializedb /path/to/config.ini [...]"
+            )

--- a/caramel/config.py
+++ b/caramel/config.py
@@ -4,7 +4,9 @@ import argparse
 import os
 
 
-def add_inifile_argument(parser, env=os.environ):
+def add_inifile_argument(parser, env=None):
+    if env is None:
+        env = os.environ
     default_ini = env.get("CARAMEL_INI")
 
     parser.add_argument(
@@ -13,11 +15,11 @@ def add_inifile_argument(parser, env=os.environ):
         dest="inifile",
         default=default_ini,
         type=str,
-        action=check_inifile_path_set,
+        action=CheckInifilePathSet,
     )
 
 
-class check_inifile_path_set(argparse.Action):
+class CheckInifilePathSet(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         setattr(namespace, self.dest, values)
         inifile = getattr(namespace, self.dest, None)

--- a/caramel/config.py
+++ b/caramel/config.py
@@ -1,10 +1,14 @@
 #! /usr/bin/env python
 # vim: expandtab shiftwidth=4 softtabstop=4 tabstop=17 filetype=python :
+"""caramel.config is a helper library that standardizes and collects the logic
+ in one place used by the caramel CLI tools/scripts"""
 import argparse
 import os
 
 
 def add_inifile_argument(parser, env=None):
+    """Adds an argument to the parser for the config-file, defaults to
+    CARAMEL_INI in the environment"""
     if env is None:
         env = os.environ
     default_ini = env.get("CARAMEL_INI")
@@ -20,6 +24,9 @@ def add_inifile_argument(parser, env=None):
 
 
 class CheckInifilePathSet(argparse.Action):
+    """An arparse.Action to raise an error if no config file has been
+    defined by the user or  in the environment"""
+
     def __call__(self, parser, namespace, values, option_string=None):
         setattr(namespace, self.dest, values)
         inifile = getattr(namespace, self.dest, None)

--- a/caramel/scripts/autosign.py
+++ b/caramel/scripts/autosign.py
@@ -23,6 +23,7 @@ shouldn't have your private key accessible by the web-application.
 it."""
 
 import argparse
+
 import transaction
 import sys
 import logging
@@ -35,6 +36,7 @@ from pyramid.paster import bootstrap
 from sqlalchemy import create_engine
 
 import caramel.models as models
+from caramel import config
 
 logger = logging.getLogger(__name__)
 
@@ -79,7 +81,7 @@ def mainloop(delay, ca, delta):
 def cmdline():
     """Basically just parsing the arguments and returning them"""
     parser = argparse.ArgumentParser()
-    parser.add_argument("inifile")
+    config.add_inifile_argument(parser)
     parser.add_argument("--delay", help="How long to sleep. (ms)")
     parser.add_argument("--valid", help="How many hours the certificate is valid for")
     args = parser.parse_args()

--- a/caramel/scripts/generate_ca.py
+++ b/caramel/scripts/generate_ca.py
@@ -7,6 +7,7 @@ import uuid
 import os
 import OpenSSL.crypto as _crypto
 from pyramid.paster import bootstrap
+from caramel import config
 
 VERSION = 0x2
 CA_BITS = 4096
@@ -162,7 +163,7 @@ def write_files(key, keyname, cert, certname):
 
 def cmdline():
     parser = argparse.ArgumentParser()
-    parser.add_argument("inifile", help="Needed to find CA filename")
+    config.add_inifile_argument(parser)
     args = parser.parse_args()
     return args
 

--- a/caramel/scripts/initializedb.py
+++ b/caramel/scripts/initializedb.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 # vim: expandtab shiftwidth=4 softtabstop=4 tabstop=17 filetype=python :
-import os
-import sys
+import argparse
 
 from sqlalchemy import engine_from_config
 
@@ -10,19 +9,20 @@ from pyramid.paster import (
     setup_logging,
 )
 
-from ..models import init_session
+import caramel.config as config
+from caramel.models import init_session
 
 
-def usage(argv):
-    cmd = os.path.basename(argv[0])
-    print("usage: %s <config_uri>\n" '(example: "%s development.ini")' % (cmd, cmd))
-    sys.exit(1)
+def cmdline():
+    parser = argparse.ArgumentParser()
+    config.add_inifile_argument(parser)
+    args = parser.parse_args()
+    return args
 
 
-def main(argv=sys.argv):
-    if len(argv) != 2:
-        usage(argv)
-    config_uri = argv[1]
+def main():
+    args = cmdline()
+    config_uri = args.inifile
     setup_logging(config_uri)
     settings = get_appsettings(config_uri)
     engine = engine_from_config(settings, "sqlalchemy.")

--- a/caramel/scripts/tool.py
+++ b/caramel/scripts/tool.py
@@ -3,6 +3,7 @@
 
 import argparse
 
+from caramel import config
 from pyramid.paster import bootstrap
 from pyramid.settings import asbool
 from sqlalchemy import create_engine
@@ -16,7 +17,7 @@ import concurrent.futures
 
 def cmdline():
     parser = argparse.ArgumentParser()
-    parser.add_argument("inifile")
+    config.add_inifile_argument(parser)
     parser.add_argument(
         "--long",
         help="Generate a long lived cert(1 year)",
@@ -68,7 +69,6 @@ def cmdline():
     )
 
     args = parser.parse_args()
-
     # Didn't find a way to do this with argparse, but I didn't look too hard.
     return args
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,45 @@
+#! /usr/bin/env python
+# vim: expandtab shiftwidth=4 softtabstop=4 tabstop=17 filetype=python :
+import argparse
+import unittest
+
+from caramel import config
+
+
+class TestConfig(unittest.TestCase):
+    def test_inifile_argument(self):
+        my_ini = "/a/path/to/my_ini_file.ini"
+
+        parser = argparse.ArgumentParser()
+        config.add_inifile_argument(parser, {})
+        args = parser.parse_args([my_ini])
+
+        self.assertEqual(args.inifile, my_ini)
+
+    def test_inifile_env(self):
+        my_ini = "/a/path/to/my_ini_file.ini"
+        env = {"CARAMEL_INI": my_ini}
+
+        parser = argparse.ArgumentParser()
+        config.add_inifile_argument(parser, env)
+        args = parser.parse_args([])
+
+        self.assertEqual(args.inifile, my_ini)
+
+    def test_inifile_argument_env(self):
+        my_ini = "/a/path/to/my_ini_file.ini"
+        other_ini = "/a/path/to/other_ini_file.ini"
+        env = {"CARAMEL_INI": other_ini}
+
+        parser = argparse.ArgumentParser()
+        config.add_inifile_argument(parser, env)
+        args = parser.parse_args([my_ini])
+
+        self.assertEqual(args.inifile, my_ini)
+
+    def test_no_ini_path(self):
+        parser = argparse.ArgumentParser()
+        config.add_inifile_argument(parser, {})
+
+        with self.assertRaises(ValueError):
+            parser.parse_args([])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 # vim: expandtab shiftwidth=4 softtabstop=4 tabstop=17 filetype=python :
+"""tests.test_config contains the unittests for caramel.config"""
 import argparse
 import unittest
 
@@ -7,7 +8,10 @@ from caramel import config
 
 
 class TestConfig(unittest.TestCase):
+    """Tests for the caramel.config library"""
+
     def test_inifile_argument(self):
+        """path as argument, no path in the environment"""
         my_ini = "/a/path/to/my_ini_file.ini"
 
         parser = argparse.ArgumentParser()
@@ -17,6 +21,7 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(args.inifile, my_ini)
 
     def test_inifile_env(self):
+        """path in the environment, no path argument"""
         my_ini = "/a/path/to/my_ini_file.ini"
         env = {"CARAMEL_INI": my_ini}
 
@@ -27,6 +32,8 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(args.inifile, my_ini)
 
     def test_inifile_argument_env(self):
+        """different paths as argument and in environment,
+        argument takes priority"""
         my_ini = "/a/path/to/my_ini_file.ini"
         other_ini = "/a/path/to/other_ini_file.ini"
         env = {"CARAMEL_INI": other_ini}
@@ -38,6 +45,7 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(args.inifile, my_ini)
 
     def test_no_ini_path(self):
+        """no path in either argument or evironment, should raise ValueError"""
         parser = argparse.ArgumentParser()
         config.add_inifile_argument(parser, {})
 


### PR DESCRIPTION
A first implementation of a new way to handle the configuration of the caramel tools/scripts as requested in issue  #55. This first implementation makes it possible for the user to set the path to the .ini-file in the environment(the variable CARAMEL_INI) instead of as an argument to the script. The idea being to make it possible in the future to be able to configure via the setting of environment variables instead of a .ini-file, while also still being compatible with the current way of configuration.