### PR TITLE
Drop python2 compatibility and make the CI happier

### DIFF
--- a/caramel/__init__.py
+++ b/caramel/__init__.py
@@ -1,16 +1,5 @@
 #! /usr/bin/env python
 # vim: expandtab shiftwidth=4 softtabstop=4 tabstop=17 filetype=python :
-
-# Make things as three-ish as possible (requires python >= 2.6)
-from __future__ import unicode_literals, print_function, absolute_import, division
-
-# Namespace cleanup
-del unicode_literals, print_function, absolute_import, division
-
-#
-# ----- End header -----
-#
-
 from pyramid.config import Configurator
 from sqlalchemy import engine_from_config
 

--- a/caramel/__init__.py
+++ b/caramel/__init__.py
@@ -2,8 +2,8 @@
 # vim: expandtab shiftwidth=4 softtabstop=4 tabstop=17 filetype=python :
 
 # Make things as three-ish as possible (requires python >= 2.6)
-from __future__ import (unicode_literals, print_function,
-                        absolute_import, division)
+from __future__ import unicode_literals, print_function, absolute_import, division
+
 # Namespace cleanup
 del unicode_literals, print_function, absolute_import, division
 
@@ -16,12 +16,11 @@ from sqlalchemy import engine_from_config
 
 from .models import (
     init_session,
-    )
+)
 
 
 def main(global_config, **settings):
-    """ This function returns a Pyramid WSGI application.
-    """
+    """This function returns a Pyramid WSGI application."""
     engine = engine_from_config(settings, "sqlalchemy.")
     init_session(engine)
     config = Configurator(settings=settings)

--- a/caramel/models.py
+++ b/caramel/models.py
@@ -179,9 +179,7 @@ class CSR(Base):
     @_reify
     def subject_components(self):
         components = self.subject.get_components()
-        return tuple(
-            (n.decode("utf8"), v.decode("utf8")) for n, v in components
-        )
+        return tuple((n.decode("utf8"), v.decode("utf8")) for n, v in components)
 
     @classmethod
     def valid(cls):
@@ -212,10 +210,7 @@ class CSR(Base):
         # instead batch load the certificates at once
         all_signed = _sa.select([Certificate.csr_id])
         return (
-            cls.query()
-            .filter_by(rejected=False)
-            .filter(CSR.id.in_(all_signed))
-            .all()
+            cls.query().filter_by(rejected=False).filter(CSR.id.in_(all_signed)).all()
         )
 
     @classmethod
@@ -265,8 +260,7 @@ class AccessLog(Base):
 
     def __str__(self):
         return (
-            "<{0.__class__.__name__} id={0.id} "
-            "csr={0.csr.sha256sum} when={0.when}>"
+            "<{0.__class__.__name__} id={0.id} " "csr={0.csr.sha256sum} when={0.when}>"
         ).format(self)
 
     def __repr__(self):
@@ -344,9 +338,7 @@ class Certificate(Base):
         return "<{0.__class__.__name__} id={0.id}>".format(self)
 
     @classmethod
-    def sign(
-        cls, CSR, ca, lifetime=_datetime.timedelta(30 * 3), backdate=False
-    ):
+    def sign(cls, CSR, ca, lifetime=_datetime.timedelta(30 * 3), backdate=False):
         """Takes a CSR, signs it, generating and returning a Certificate.
         backdate causes the CA to set "notBefore" of signed certificates to
         match that of the CA Certificate. This is an ugly workaround for a

--- a/caramel/scripts/autosign.py
+++ b/caramel/scripts/autosign.py
@@ -66,8 +66,7 @@ def mainloop(delay, ca, delta):
     with concurrent.futures.ThreadPoolExecutor(max_workers=16) as executor:
         while True:
             csrs = models.CSR.unsigned()
-            futures = [executor.submit(csr_sign, csr, ca, delta)
-                       for csr in csrs]
+            futures = [executor.submit(csr_sign, csr, ca, delta) for csr in csrs]
 
             time.sleep(delay)
             for future in concurrent.futures.as_completed(futures):
@@ -82,8 +81,7 @@ def cmdline():
     parser = argparse.ArgumentParser()
     parser.add_argument("inifile")
     parser.add_argument("--delay", help="How long to sleep. (ms)")
-    parser.add_argument("--valid",
-                        help="How many hours the certificate is valid for")
+    parser.add_argument("--valid", help="How many hours the certificate is valid for")
     args = parser.parse_args()
     return args
 
@@ -101,11 +99,11 @@ def main():
     logger.setLevel(logging.DEBUG)
     args = cmdline()
     env = bootstrap(args.inifile)
-    settings, closer = env['registry'].settings, env['closer']
-    engine = create_engine(settings['sqlalchemy.url'])
+    settings, closer = env["registry"].settings, env["closer"]
+    engine = create_engine(settings["sqlalchemy.url"])
     models.init_session(engine)
-    delay = int(settings.get('delay', 500)) / 1000
-    valid = int(settings.get('valid', 3))
+    delay = int(settings.get("delay", 500)) / 1000
+    valid = int(settings.get("valid", 3))
     delta = datetime.timedelta(days=0, hours=valid)
     del valid
 

--- a/caramel/scripts/generate_ca.py
+++ b/caramel/scripts/generate_ca.py
@@ -16,10 +16,11 @@ CA_YEARS = 24  # Beware of unixtime ;)
 
 CA_EXTENSIONS = [
     # Key usage for a CA cert.
-    _crypto.X509Extension(b"basicConstraints", critical=True,
-                          value=b"CA:true, pathlen:0"),
+    _crypto.X509Extension(
+        b"basicConstraints", critical=True, value=b"CA:true, pathlen:0"
+    ),
     # no cRLSign as we do not use CRLs in caramel.
-    _crypto.X509Extension(b"keyUsage", critical=True, value=b"keyCertSign")
+    _crypto.X509Extension(b"keyUsage", critical=True, value=b"keyCertSign"),
 ]
 
 
@@ -28,7 +29,7 @@ def _crypto_patch():
     https://github.com/pyca/pyopenssl/pull/115 has a pull&fix for it
     https://github.com/pyca/pyopenssl/issues/129 is an open issue
     about it."""
-    _crypto._lib.ASN1_STRING_set_default_mask_asc(b'utf8only')
+    _crypto._lib.ASN1_STRING_set_default_mask_asc(b"utf8only")
 
 
 _crypto_patch()
@@ -37,8 +38,8 @@ _crypto_patch()
 # Hack hack. :-)
 def CA_LIFE():
     d = datetime.date.today()
-    t = datetime.date(d.year+CA_YEARS, d.month, d.day)
-    return int((t-d).total_seconds())
+    t = datetime.date(d.year + CA_YEARS, d.month, d.day)
+    return int((t - d).total_seconds())
 
 
 # adapted from models.py
@@ -48,7 +49,7 @@ def components(subject):
 
 
 def matching_template(x509, cacert):
-    """ Takes a subject as a dict, and returns if all required fields
+    """Takes a subject as a dict, and returns if all required fields
     match. Otherwise raises exception"""
 
     def later_check(subject):
@@ -71,8 +72,7 @@ def matching_template(x509, cacert):
 
     for (ca, sub) in zip(casubject, subject):
         if ca != sub:
-            raise ValueError("Subject needs to match CA cert:"
-                             "{}".format(casubject))
+            raise ValueError("Subject needs to match CA cert:" "{}".format(casubject))
 
 
 def sign_req(req, cacert, cakey):
@@ -104,18 +104,19 @@ def sign_req(req, cacert, cakey):
 
     cacert = cert
 
-    extension = _crypto.X509Extension(b"subjectKeyIdentifier",
-                                      critical=False,
-                                      value=b"hash",
-                                      subject=cert)
+    extension = _crypto.X509Extension(
+        b"subjectKeyIdentifier", critical=False, value=b"hash", subject=cert
+    )
     cert.add_extensions([extension])
 
     # We need subjectKeyIdentifier to be added before we can add
     # authorityKeyIdentifier.
-    extension = _crypto.X509Extension(b"authorityKeyIdentifier",
-                                      critical=False,
-                                      value=b"issuer:always,keyid:always",
-                                      issuer=cacert)
+    extension = _crypto.X509Extension(
+        b"authorityKeyIdentifier",
+        critical=False,
+        value=b"issuer:always,keyid:always",
+        issuer=cacert,
+    )
     cert.add_extensions([extension])
 
     cert.sign(cakey, "sha512")
@@ -147,10 +148,9 @@ def create_ca(subject):
 
 
 def write_files(key, keyname, cert, certname):
-
     def writefile(data, name):
-        with open(name, 'w') as f:
-            stream = data.decode('utf8')
+        with open(name, "w") as f:
+            stream = data.decode("utf8")
             f.write(stream)
 
     _key = _crypto.dump_privatekey(_crypto.FILETYPE_PEM, key)
@@ -188,8 +188,7 @@ def build_ca(keyname, certname):
     template = tuple(template)
 
     key, req, cert = create_ca(template)
-    write_files(key=key, keyname=keyname,
-                cert=cert, certname=certname)
+    write_files(key=key, keyname=keyname, cert=cert, certname=certname)
 
 
 def main():

--- a/caramel/scripts/initializedb.py
+++ b/caramel/scripts/initializedb.py
@@ -1,16 +1,5 @@
 #! /usr/bin/env python
 # vim: expandtab shiftwidth=4 softtabstop=4 tabstop=17 filetype=python :
-
-# Make things as three-ish as possible (requires python >= 2.6)
-from __future__ import unicode_literals, print_function, absolute_import, division
-
-# Namespace cleanup
-del unicode_literals, print_function, absolute_import, division
-
-#
-# ----- End header -----
-#
-
 import os
 import sys
 

--- a/caramel/scripts/initializedb.py
+++ b/caramel/scripts/initializedb.py
@@ -2,8 +2,8 @@
 # vim: expandtab shiftwidth=4 softtabstop=4 tabstop=17 filetype=python :
 
 # Make things as three-ish as possible (requires python >= 2.6)
-from __future__ import (unicode_literals, print_function,
-                        absolute_import, division)
+from __future__ import unicode_literals, print_function, absolute_import, division
+
 # Namespace cleanup
 del unicode_literals, print_function, absolute_import, division
 
@@ -19,15 +19,14 @@ from sqlalchemy import engine_from_config
 from pyramid.paster import (
     get_appsettings,
     setup_logging,
-    )
+)
 
 from ..models import init_session
 
 
 def usage(argv):
     cmd = os.path.basename(argv[0])
-    print('usage: %s <config_uri>\n'
-          '(example: "%s development.ini")' % (cmd, cmd))
+    print("usage: %s <config_uri>\n" '(example: "%s development.ini")' % (cmd, cmd))
     sys.exit(1)
 
 
@@ -37,5 +36,5 @@ def main(argv=sys.argv):
     config_uri = argv[1]
     setup_logging(config_uri)
     settings = get_appsettings(config_uri)
-    engine = engine_from_config(settings, 'sqlalchemy.')
+    engine = engine_from_config(settings, "sqlalchemy.")
     init_session(engine, create=True)

--- a/caramel/scripts/tool.py
+++ b/caramel/scripts/tool.py
@@ -88,9 +88,7 @@ def print_list():
 
     for csr_id, csr_commonname, csr_sha256sum, not_after in valid_requests:
         not_after = "----------" if not_after is None else str(not_after)
-        output = " ".join(
-            (str(csr_id), csr_commonname, csr_sha256sum, not_after)
-        )
+        output = " ".join((str(csr_id), csr_commonname, csr_sha256sum, not_after))
         # TODO: Add lifetime of latest (fetched?) cert for the key.
         print(output)
 
@@ -183,9 +181,7 @@ def csr_resign(ca, lifetime_short, lifetime_long, backdate):
         except Exception:
             error_out("Not found or some other error")
         futures = (
-            executor.submit(
-                refresh, csr, ca, lifetime_short, lifetime_long, backdate
-            )
+            executor.submit(refresh, csr, ca, lifetime_short, lifetime_long, backdate)
             for csr in csrlist
         )
         for future in concurrent.futures.as_completed(futures):

--- a/caramel/views.py
+++ b/caramel/views.py
@@ -2,8 +2,8 @@
 # vim: expandtab shiftwidth=4 softtabstop=4 tabstop=17 filetype=python :
 
 # Make things as three-ish as possible (requires python >= 2.6)
-from __future__ import (unicode_literals, print_function,
-                        absolute_import, division)
+from __future__ import unicode_literals, print_function, absolute_import, division
+
 # Namespace cleanup
 del unicode_literals, print_function, absolute_import, division
 
@@ -18,8 +18,8 @@ from pyramid.httpexceptions import (
     HTTPBadRequest,
     HTTPNotFound,
     HTTPForbidden,
-    HTTPError
-    )
+    HTTPError,
+)
 from pyramid.view import view_config
 
 from hashlib import sha256
@@ -29,7 +29,7 @@ from .models import (
     CSR,
     AccessLog,
     SigningCert,
-    )
+)
 
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
@@ -38,7 +38,7 @@ from sqlalchemy.orm.exc import NoResultFound
 # 2 kbyte should be enough for up to 4 kbit keys.
 # XXX: This should probably be handled outside of app (i.e. by the
 #      server), or at least be configurable.
-_MAXLEN = 2 * 2**10
+_MAXLEN = 2 * 2 ** 10
 
 
 def raise_for_length(req, limit=_MAXLEN):
@@ -48,9 +48,7 @@ def raise_for_length(req, limit=_MAXLEN):
     if length is None:
         raise HTTPLengthRequired
     if length > limit:
-        raise HTTPRequestEntityTooLarge(
-            "Max size: {0} kB".format(limit / 2**10)
-            )
+        raise HTTPRequestEntityTooLarge("Max size: {0} kB".format(limit / 2 ** 10))
 
 
 def raise_for_subject(components, required_prefix):
@@ -65,11 +63,7 @@ def raise_for_subject(components, required_prefix):
 # XXX: Is this the right way? Catch-class JSON converter of Exceptions
 @view_config(context=HTTPError)
 def HTTPErrorToJson(exc, request):
-    exc.json_body = {
-        "status": exc.code,
-        "title": exc.title,
-        "detail": exc.detail
-    }
+    exc.json_body = {"status": exc.code, "title": exc.title, "detail": exc.detail}
     exc.content_type = "application/problem+json"
     request.response = exc
     return request.response
@@ -123,23 +117,23 @@ def cert_fetch(request):
     if cert:
         if datetime.utcnow() < cert.not_after:
             # XXX: appropriate content-type is ... ?
-            return Response(cert.pem,
-                            content_type="application/octet-stream",
-                            charset="UTF-8")
+            return Response(
+                cert.pem, content_type="application/octet-stream", charset="UTF-8"
+            )
     request.response.status_int = 202
     return csr
 
 
-@view_config(route_name="ca", request_method="GET",
-             renderer="string", http_cache=3600)
+@view_config(route_name="ca", request_method="GET", renderer="string", http_cache=3600)
 def ca_fetch(request):
-    ca_file = request.registry.settings['ca.cert']
+    ca_file = request.registry.settings["ca.cert"]
     ca = SigningCert.from_files(ca_file)
     return ca.pem.decode("utf8")
 
 
-@view_config(route_name="cabundle", request_method="GET",
-             renderer="string", http_cache=3600)
+@view_config(
+    route_name="cabundle", request_method="GET", renderer="string", http_cache=3600
+)
 def ca_bundle_fetch(request):
     """Attempt to return a bunle of all our intermediates"""
     bundle = ca_fetch(request)

--- a/caramel/views.py
+++ b/caramel/views.py
@@ -1,17 +1,10 @@
 #! /usr/bin/env python
 # vim: expandtab shiftwidth=4 softtabstop=4 tabstop=17 filetype=python :
-
-# Make things as three-ish as possible (requires python >= 2.6)
-from __future__ import unicode_literals, print_function, absolute_import, division
-
-# Namespace cleanup
-del unicode_literals, print_function, absolute_import, division
-
-#
-# ----- End header -----
-#
+from hashlib import sha256
+from datetime import datetime
 
 from pyramid.response import Response
+from pyramid.view import view_config
 from pyramid.httpexceptions import (
     HTTPLengthRequired,
     HTTPRequestEntityTooLarge,
@@ -20,10 +13,9 @@ from pyramid.httpexceptions import (
     HTTPForbidden,
     HTTPError,
 )
-from pyramid.view import view_config
 
-from hashlib import sha256
-from datetime import datetime
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm.exc import NoResultFound
 
 from .models import (
     CSR,
@@ -31,8 +23,6 @@ from .models import (
     SigningCert,
 )
 
-from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm.exc import NoResultFound
 
 # Maximum length allowed for csr uploads.
 # 2 kbyte should be enough for up to 4 kbit keys.

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,3 +25,7 @@ domain = caramel
 input_file = caramel/locale/caramel.pot
 output_dir = caramel/locale
 previous = true
+
+[flake8]
+max-line-length = 88
+extend-ignore = E203

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,8 +2,8 @@
 # vim: expandtab shiftwidth=4 softtabstop=4 tabstop=17 filetype=python :
 
 # Make things as three-ish as possible (requires python >= 2.6)
-from __future__ import (unicode_literals, print_function,
-                        absolute_import, division)
+from __future__ import unicode_literals, print_function, absolute_import, division
+
 # Namespace cleanup
 del unicode_literals, print_function, absolute_import, division
 
@@ -17,7 +17,7 @@ import transaction
 from caramel.models import (
     init_session,
     DBSession,
-    )
+)
 
 from . import fixtures
 
@@ -34,6 +34,7 @@ class ModelTestCase(unittest.TestCase):
         # Clear existing session, if any.
         DBSession.remove()
         from sqlalchemy import create_engine
+
         engine = create_engine("sqlite://")
         init_session(engine, create=True)
         with transaction.manager:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,17 +1,8 @@
 #! /usr/bin/env python
 # vim: expandtab shiftwidth=4 softtabstop=4 tabstop=17 filetype=python :
-
-# Make things as three-ish as possible (requires python >= 2.6)
-from __future__ import unicode_literals, print_function, absolute_import, division
-
-# Namespace cleanup
-del unicode_literals, print_function, absolute_import, division
-
-#
-# ----- End header -----
-#
-
 import unittest
+from itertools import zip_longest
+
 import transaction
 
 from caramel.models import (
@@ -20,11 +11,6 @@ from caramel.models import (
 )
 
 from . import fixtures
-
-try:
-    from itertools import zip_longest
-except ImportError:
-    from itertools import izip_longest as zip_longest
 
 
 class ModelTestCase(unittest.TestCase):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,35 +1,16 @@
 #! /usr/bin/env python
 # vim: expandtab shiftwidth=4 softtabstop=4 tabstop=17 filetype=python :
-
-# Make things as three-ish as possible (requires python >= 2.6)
-from __future__ import unicode_literals, print_function, absolute_import, division
-
-# Namespace cleanup
-del unicode_literals, print_function, absolute_import, division
-
-#
-# ----- End header -----
-#
-
 from textwrap import dedent
 from hashlib import sha256
 from operator import attrgetter
-
-try:
-    from itertools import zip_longest
-except ImportError:
-    from itertools import izip_longest as zip_longest
-
 from datetime import datetime, timedelta
+from itertools import zip_longest
+
+from caramel import models, views
 
 day = timedelta(days=1)
 year = 365 * day  # close enough
 now = datetime.now()
-
-from caramel import (
-    models,
-    views,
-)
 
 
 class defaultproperty(object):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -2,8 +2,8 @@
 # vim: expandtab shiftwidth=4 softtabstop=4 tabstop=17 filetype=python :
 
 # Make things as three-ish as possible (requires python >= 2.6)
-from __future__ import (unicode_literals, print_function,
-                        absolute_import, division)
+from __future__ import unicode_literals, print_function, absolute_import, division
+
 # Namespace cleanup
 del unicode_literals, print_function, absolute_import, division
 
@@ -21,14 +21,15 @@ except ImportError:
     from itertools import izip_longest as zip_longest
 
 from datetime import datetime, timedelta
+
 day = timedelta(days=1)
-year = 365 * day                # close enough
+year = 365 * day  # close enough
 now = datetime.now()
 
 from caramel import (
     models,
     views,
-    )
+)
 
 
 class defaultproperty(object):
@@ -45,8 +46,11 @@ class SimilarityComparable(object):
 
     def match(self, other):
         excludes = set(getattr(self, "_match_excluded_attrs_", ()))
-        attrs = [attr for attr in dir(self)
-                 if not attr.startswith("_") and attr not in excludes]
+        attrs = [
+            attr
+            for attr in dir(self)
+            if not attr.startswith("_") and attr not in excludes
+        ]
         if not attrs:
             return True
         getter = attrgetter(*attrs)
@@ -66,12 +70,14 @@ class AttributeCollection(object):
 
 
 class CSRFixture(AttributeCollection, SimilarityComparable):
-    __relations = ("accessed", "certificates",)
+    __relations = (
+        "accessed",
+        "certificates",
+    )
 
     @property
     def _match_excluded_attrs_(self):
-        return (super(CSRFixture, self)._match_excluded_attrs_ +
-                self.__relations)
+        return super(CSRFixture, self)._match_excluded_attrs_ + self.__relations
 
     @defaultproperty
     def sha256sum(self):
@@ -118,14 +124,18 @@ class AccessLogFixture(AttributeCollection, SimilarityComparable):
 
 
 # "Correct" subject prefix for test data
-subject_prefix = (('O', 'Example inc.'), ('OU', 'Example Dept'),)
+subject_prefix = (
+    ("O", "Example inc."),
+    ("OU", "Example Dept"),
+)
 
 
 class CertificateData(object):
     initial = CertificateFixture(
         not_before=now - 2 * year,
         not_after=now + 2 * year,
-        pem=dedent("""\
+        pem=dedent(
+            """\
             -----BEGIN CERTIFICATE-----
             MIIEVDCCAjygAwIBAgIBZTANBgkqhkiG9w0BAQsFADAmMSQwIgYDVQQDDBtDYXJh
             bWVsIFNpZ25pbmcgQ2VydGlmaWNhdGUwHhcNMTQwODA4MTM0NDA0WhcNMTQxMDA4
@@ -152,13 +162,15 @@ class CertificateData(object):
             n4rH2rFn8rcQwSaRyE9NcOpirCur43MR42+LAfZq5s9j7CuQJTw6G0wvCHGqRIQ9
             X1qbQOxg6ig=
             -----END CERTIFICATE-----
-            """).encode("utf8"),
-        )
+            """
+        ).encode("utf8"),
+    )
 
     expired = CertificateFixture(
         not_before=initial.not_before,
         not_after=now - 1 * day,
-        pem=dedent("""\
+        pem=dedent(
+            """\
             -----BEGIN CERTIFICATE-----
             MIIEVTCCAj2gAwIBAgIBaDANBgkqhkiG9w0BAQsFADAmMSQwIgYDVQQDDBtDYXJh
             bWVsIFNpZ25pbmcgQ2VydGlmaWNhdGUwHhcNMTQwODA4MTM1OTUxWhcNMTQxMDA4
@@ -185,21 +197,29 @@ class CertificateData(object):
             7CRL6mRM5+q4ICfesXzUXpPYjgD2UexIjSJNoYjiu3aKpjwvrZ88t8hPR46Uac7E
             5yvm61Agw/Tg
             -----END CERTIFICATE-----
-            """).encode("utf8"),
-        )
+            """
+        ).encode("utf8"),
+    )
 
     ca_cert = CertificateFixture(
         not_before=initial.not_before,
         not_after=initial.not_after,
-        subject=(('C', 'SE'), ('ST', 'Östergötland'),
-                 ('L', 'Norrköping'), ('O', 'Muppar AB'),
-                 ('OU', 'Muppar Teknik'),
-                 ('CN', 'Caramel Signing Certificate')),
-
-        common_subject=(('C', 'SE'), ('ST', 'Östergötland'),
-                        ('L', 'Norrköping'), ('O', 'Muppar AB')),
-
-        pem=dedent("""\
+        subject=(
+            ("C", "SE"),
+            ("ST", "Östergötland"),
+            ("L", "Norrköping"),
+            ("O", "Muppar AB"),
+            ("OU", "Muppar Teknik"),
+            ("CN", "Caramel Signing Certificate"),
+        ),
+        common_subject=(
+            ("C", "SE"),
+            ("ST", "Östergötland"),
+            ("L", "Norrköping"),
+            ("O", "Muppar AB"),
+        ),
+        pem=dedent(
+            """\
             -----BEGIN CERTIFICATE-----
             MIIGwDCCBKigAwIBAgIRAJSEOECNQRHkq2SMiaXBGsIwDQYJKoZIhvcNAQENBQAw
             gY4xCzAJBgNVBAYTAlNFMRcwFQYDVQQIDA7DlnN0ZXJnw7Z0bGFuZDEUMBIGA1UE
@@ -239,28 +259,30 @@ class CertificateData(object):
             EybN1zenahQmhX4ljI5OSMYBP3gpkRu2HvP5SOwN28QHq2+mgCFxzdfdtiWoJ8a0
             7eLmmg==
             -----END CERTIFICATE-----
-            """).encode("utf8"),
-        )
+            """
+        ).encode("utf8"),
+    )
     # FIXME: add more certificates here, once we have something to test.
 
 
 class AccessLogData(object):
     initial_1 = AccessLogFixture(
         when=CertificateData.initial.not_before + 30 * day,
-        addr="127.0.0.1",       # XXX: bytestring or unicode string?
-        )
+        addr="127.0.0.1",  # XXX: bytestring or unicode string?
+    )
 
     initial_2 = AccessLogFixture(
         when=now - 3 * day,
         addr="127.0.0.127",
-        )
+    )
 
 
 class CSRData(object):
     initial = CSRFixture(
         orgunit="Example Dept",
         commonname="foo.example.com",
-        pem=dedent("""\
+        pem=dedent(
+            """\
             -----BEGIN CERTIFICATE REQUEST-----
             MIICjTCCAXUCAQIwSDEVMBMGA1UECgwMRXhhbXBsZSBpbmMuMRUwEwYDVQQLDAxF
             eGFtcGxlIERlcHQxGDAWBgNVBAMMD2Zvby5leGFtcGxlLmNvbTCCASIwDQYJKoZI
@@ -277,11 +299,14 @@ class CSRData(object):
             O+jruZshnFL0KQybIokYGLLcb6NixdsCTSw+rfztuLUEEMP1ozNCgk8TX8mXWduM
             XIP49FHFe6IjLuj0ofRXiJPmS+4ToqRbNIBRoz7kSLov
             -----END CERTIFICATE REQUEST-----
-            """).encode("utf8"),  # py3 dedent can't handle bytes
+            """
+        ).encode(
+            "utf8"
+        ),  # py3 dedent can't handle bytes
         subject_components=(
-            ('O', 'Example inc.'),
-            ('OU', 'Example Dept'),
-            ('CN', 'foo.example.com'),
+            ("O", "Example inc."),
+            ("OU", "Example Dept"),
+            ("CN", "foo.example.com"),
         ),
         accessed=[
             AccessLogData.initial_2,
@@ -290,12 +315,13 @@ class CSRData(object):
         certificates=[
             CertificateData.initial,
         ],
-        )
+    )
 
     with_expired_cert = CSRFixture(
         orgunit="Example Dept",
         commonname="spam.example.com",
-        pem=dedent("""\
+        pem=dedent(
+            """\
             -----BEGIN CERTIFICATE REQUEST-----
             MIICjjCCAXYCAQIwSTEVMBMGA1UECgwMRXhhbXBsZSBpbmMuMRUwEwYDVQQLDAxF
             eGFtcGxlIERlcHQxGTAXBgNVBAMMEHNwYW0uZXhhbXBsZS5jb20wggEiMA0GCSqG
@@ -312,21 +338,25 @@ class CSRData(object):
             oQN1HuxKCScUJ9Vtr0dnBLGAf62vAqv5yZYhl9Qnt5EJ9OtspWm0e8FwTjNmoA/z
             qnvUxskzM2ItxVV9oa9YDTid0GbJvF67QJQyVIO0Vz4uwg==
             -----END CERTIFICATE REQUEST-----
-            """).encode("utf8"),  # py3 dedent can't handle bytes
+            """
+        ).encode(
+            "utf8"
+        ),  # py3 dedent can't handle bytes
         subject_components=(
-            ('O', 'Example inc.'),
-            ('OU', 'Example Dept'),
-            ('CN', 'spam.example.com'),
+            ("O", "Example inc."),
+            ("OU", "Example Dept"),
+            ("CN", "spam.example.com"),
         ),
         certificates=[
             CertificateData.expired,
         ],
-        )
+    )
 
     good = CSRFixture(
         orgunit="Example Dept",
         commonname="bar.example.com",
-        pem=dedent("""\
+        pem=dedent(
+            """\
             -----BEGIN CERTIFICATE REQUEST-----
             MIICjTCCAXUCAQIwSDEVMBMGA1UECgwMRXhhbXBsZSBpbmMuMRUwEwYDVQQLDAxF
             eGFtcGxlIERlcHQxGDAWBgNVBAMMD2Jhci5leGFtcGxlLmNvbTCCASIwDQYJKoZI
@@ -343,16 +373,18 @@ class CSRData(object):
             MN1FxWzEy4yXgzW8uv+lX6yyTtkfrC7e3LFiAuoUlBeD5GmsVd30Xz5iGnuQv3d0
             fekjT5Np8XIS2ERJmx4CIjs5VpE1FMNOMoJ35kQpkQaQ
             -----END CERTIFICATE REQUEST-----
-            """).encode("utf8"),
+            """
+        ).encode("utf8"),
         subject_components=(
-            ('O', 'Example inc.'),
-            ('OU', 'Example Dept'),
-            ('CN', 'bar.example.com'),
+            ("O", "Example inc."),
+            ("OU", "Example Dept"),
+            ("CN", "bar.example.com"),
         ),
-        )
+    )
 
     bad_signature = CSRFixture(  # `good` with the subject of `initial`
-        pem=dedent("""\
+        pem=dedent(
+            """\
             -----BEGIN CERTIFICATE REQUEST-----
             MIIBAjCBrQIBADBIMRUwEwYDVQQKDAxFeGFtcGxlIGluYy4xFTATBgNVBAsMDEV4
             YW1wbGUgRGVwdDEYMBYGA1UEAwwPZm9vLmV4YW1wbGUuY29tMFwwDQYJKoZIhvcN
@@ -361,21 +393,25 @@ class CSRData(object):
             BQUAA0EAcsrzTdYBqlbq/JQaMSEoi64NmoxiC8GGzOaKlTxqRc7PKb+T1wN94PxJ
             faXw8kA8p0E6hmwFAE9QVkuTKvP/eg==
             -----END CERTIFICATE REQUEST-----
-            """).encode("utf8"),
-        )
+            """
+        ).encode("utf8"),
+    )
 
     truncated = CSRFixture(
-        pem=dedent("""\
+        pem=dedent(
+            """\
             -----BEGIN CERTIFICATE REQUEST-----
             MIIBAjCBrQIBADBIMRUwEwYDVQQKDAxFeGFtcGxlIGluYy4xFTATBgNVBAsMDEV4
             YW1wbGUgRGVwdDEYMBYGA1UEAwwPYmFyLmV4YW1wbGUuY29tMFwwDQYJKoZIhvcN
             AQEBBQADSwAwSAJBAKk2sD6xi/gfO3TVnoGMhUmkPDD17/qYzEvDdw/kponLTdNF
             asGx1//giKSBqBpUFt+KTz3NofK9Pf2qWWDxyUECAwEAAaAAMA0GCSqGSIb3DQEB
-            """).encode("utf8"),
-        )
+            """
+        ).encode("utf8"),
+    )
 
     trailing_content = CSRFixture(
-        pem=dedent("""\
+        pem=dedent(
+            """\
             -----BEGIN CERTIFICATE REQUEST-----
             MIIBAjCBrQIBADBIMRUwEwYDVQQKDAxFeGFtcGxlIGluYy4xFTATBgNVBAsMDEV4
             YW1wbGUgRGVwdDEYMBYGA1UEAwwPYmFyLmV4YW1wbGUuY29tMFwwDQYJKoZIhvcN
@@ -388,11 +424,13 @@ class CSRData(object):
             bar
             baz
             quux
-            """).encode("utf8"),
-        )
+            """
+        ).encode("utf8"),
+    )
 
     leading_content = CSRFixture(
-        pem=dedent("""\
+        pem=dedent(
+            """\
             foo
             bar
             baz
@@ -405,11 +443,13 @@ class CSRData(object):
             BQUAA0EAcsrzTdYBqlbq/JQaMSEoi64NmoxiC8GGzOaKlTxqRc7PKb+T1wN94PxJ
             faXw8kA8p0E6hmwFAE9QVkuTKvP/eg==
             -----END CERTIFICATE REQUEST-----
-            """).encode("utf8"),
-        )
+            """
+        ).encode("utf8"),
+    )
 
     multi_request = CSRFixture(
-        pem=dedent("""\
+        pem=dedent(
+            """\
             -----BEGIN CERTIFICATE REQUEST-----
             MIIBAjCBrQIBADBIMRUwEwYDVQQKDAxFeGFtcGxlIGluYy4xFTATBgNVBAsMDEV4
             YW1wbGUgRGVwdDEYMBYGA1UEAwwPZm9vLmV4YW1wbGUuY29tMFwwDQYJKoZIhvcN
@@ -426,11 +466,13 @@ class CSRData(object):
             BQUAA0EAcsrzTdYBqlbq/JQaMSEoi64NmoxiC8GGzOaKlTxqRc7PKb+T1wN94PxJ
             faXw8kA8p0E6hmwFAE9QVkuTKvP/eg==
             -----END CERTIFICATE REQUEST-----
-            """).encode("utf8"),
-        )
+            """
+        ).encode("utf8"),
+    )
 
     not_pem = CSRFixture(
-        pem=dedent("""\
+        pem=dedent(
+            """\
             Egg and Bacon
             Egg, Sausage and Bacon
             Egg and Spam
@@ -441,8 +483,9 @@ class CSRData(object):
             Spam, Spam, Spam, Egg and Spam
             Spam, Spam, Spam, Spam, Spam, Spam, Baked Beans,
                 Spam, Spam, Spam and Spam
-            """).encode("utf8"),
-        )
+            """
+        ).encode("utf8"),
+    )
 
     empty = CSRFixture(pem=b"")
 
@@ -451,7 +494,8 @@ class CSRData(object):
     bad_subject = CSRFixture(
         orgunit="Example test dept.",
         commonname="baz.example.com",
-        pem=dedent("""\
+        pem=dedent(
+            """\
             -----BEGIN CERTIFICATE REQUEST-----
             MIIBCDCBswIBADBOMRUwEwYDVQQKDAxFeGFtcGxlIGluYy4xGzAZBgNVBAsMEkV4
             YW1wbGUgdGVzdCBkZXB0LjEYMBYGA1UEAwwPYmF6LmV4YW1wbGUuY29tMFwwDQYJ
@@ -460,14 +504,15 @@ class CSRData(object):
             SIb3DQEBBQUAA0EAhriivXQYFbdc8QrnDjwVCX8ZGXiGKQEC66LceWDdvOy+mDu8
             gi+L6IgnptU8VmEowAPp0veIH1MWJrnGdp7M0g==
             -----END CERTIFICATE REQUEST-----
-        """).encode("utf-8"),
+        """
+        ).encode("utf-8"),
         subject_components=(
             ("O", "Example inc."),
             ("OU", "Example test dept."),
             ("CN", "baz.example.com"),
         ),
-        )
+    )
 
     large_body = CSRFixture(
         pem="".join(("foobar", "x" * views._MAXLEN)).encode("utf-8"),
-        )
+    )

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,20 +1,8 @@
 #! /usr/bin/env python
 # vim: expandtab shiftwidth=4 softtabstop=4 tabstop=17 filetype=python :
-
-# Make things as three-ish as possible (requires python >= 2.6)
-from __future__ import unicode_literals, print_function, absolute_import, division
-
-# Namespace cleanup
-del unicode_literals, print_function, absolute_import, division
-
-#
-# ----- End header -----
-#
-
+import datetime
 import unittest
 import unittest.mock
-import transaction
-import datetime
 
 from pyramid import testing
 from pyramid.response import Response
@@ -25,7 +13,7 @@ from pyramid.httpexceptions import (
     HTTPNotFound,
 )
 
-from . import fixtures, ModelTestCase
+import transaction
 
 from caramel.models import (
     init_session,
@@ -34,6 +22,8 @@ from caramel.models import (
     AccessLog,
 )
 from caramel import views
+
+from . import fixtures, ModelTestCase
 
 
 def dummypost(fix, **args):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2,8 +2,8 @@
 # vim: expandtab shiftwidth=4 softtabstop=4 tabstop=17 filetype=python :
 
 # Make things as three-ish as possible (requires python >= 2.6)
-from __future__ import (unicode_literals, print_function,
-                        absolute_import, division)
+from __future__ import unicode_literals, print_function, absolute_import, division
+
 # Namespace cleanup
 del unicode_literals, print_function, absolute_import, division
 
@@ -23,7 +23,7 @@ from pyramid.httpexceptions import (
     HTTPRequestEntityTooLarge,
     HTTPBadRequest,
     HTTPNotFound,
-    )
+)
 
 from . import fixtures, ModelTestCase
 
@@ -32,7 +32,7 @@ from caramel.models import (
     DBSession,
     CSR,
     AccessLog,
-    )
+)
 from caramel import views
 
 
@@ -41,7 +41,7 @@ def dummypost(fix, **args):
     req.body = fix.pem
     req.content_length = len(req.body)
     req.matchdict["sha256"] = fix.sha256sum
-    req.registry.settings['ca.cert'] = 'abc123.crt'
+    req.registry.settings["ca.cert"] = "abc123.crt"
     return req
 
 
@@ -159,8 +159,9 @@ class TestCertFetch(ModelTestCase):
         self.assertEqual(self.req.response.status_int, 200)
         # Verify there's a new AccessLog entry
         self.assertEqual(csr.accessed[0].addr, self.req.remote_addr)
-        self.assertAlmostEqual(csr.accessed[0].when, now,
-                               delta=datetime.timedelta(seconds=1))
+        self.assertAlmostEqual(
+            csr.accessed[0].when, now, delta=datetime.timedelta(seconds=1)
+        )
 
     def test_exists_expired(self):
         csr = fixtures.CSRData.with_expired_cert()
@@ -173,8 +174,9 @@ class TestCertFetch(ModelTestCase):
         self.assertEqual(self.req.response.status_int, 202)
         # Verify there's a new AccessLog entry
         self.assertEqual(csr.accessed[0].addr, self.req.remote_addr)
-        self.assertAlmostEqual(csr.accessed[0].when, now,
-                               delta=datetime.timedelta(seconds=1))
+        self.assertAlmostEqual(
+            csr.accessed[0].when, now, delta=datetime.timedelta(seconds=1)
+        )
 
     def test_not_signed(self):
         csr = fixtures.CSRData.good()
@@ -187,8 +189,9 @@ class TestCertFetch(ModelTestCase):
         self.assertEqual(self.req.response.status_int, 202)
         # Verify there's a new AccessLog entry
         self.assertEqual(csr.accessed[0].addr, self.req.remote_addr)
-        self.assertAlmostEqual(csr.accessed[0].when, now,
-                               delta=datetime.timedelta(seconds=1))
+        self.assertAlmostEqual(
+            csr.accessed[0].when, now, delta=datetime.timedelta(seconds=1)
+        )
         pass
 
 
@@ -197,9 +200,11 @@ class TestMyView(unittest.TestCase):
     def setUp(self):
         self.config = testing.setUp()
         from sqlalchemy import create_engine
+
         engine = create_engine("sqlite://")
         init_session(engine, create=True)
         from caramel.models import MyModel
+
         with transaction.manager:
             model = MyModel(name="one", value=55)
             model.save()
@@ -210,6 +215,7 @@ class TestMyView(unittest.TestCase):
 
     def test_it(self):
         from caramel.views import my_view
+
         request = testing.DummyRequest()
         info = my_view(request)
         self.assertEqual(info["one"].name, "one")


### PR DESCRIPTION
Dropping Python2 allows us to kill off flake8's warning about import order.

On top of that, since Python now has a useful code formatter in black, run that on the entire code-base to make sure it follows a consistent style.

This branch is based on top of the gitlab-ci branch, and should hopefully make the branch turn green completely in CI.