### PR TITLE
Add verbosity setting logic

### DIFF
--- a/caramel/scripts/generate_ca.py
+++ b/caramel/scripts/generate_ca.py
@@ -6,7 +6,10 @@ import argparse
 import uuid
 import os
 import OpenSSL.crypto as _crypto
-from pyramid.paster import bootstrap
+from pyramid.paster import (
+    bootstrap,
+    setup_logging,
+)
 from caramel import config
 
 VERSION = 0x2
@@ -164,6 +167,7 @@ def write_files(key, keyname, cert, certname):
 def cmdline():
     parser = argparse.ArgumentParser()
     config.add_inifile_argument(parser)
+    config.add_verbosity_argument(parser)
     args = parser.parse_args()
     return args
 
@@ -194,7 +198,12 @@ def build_ca(keyname, certname):
 
 def main():
     args = cmdline()
-    env = bootstrap(args.inifile)
+    config_path = args.inifile
+
+    setup_logging(config_path)
+    config.configure_log_level(args)
+
+    env = bootstrap(config_path)
     settings, closer = env["registry"].settings, env["closer"]
 
     ca_cert = settings.get("ca.cert")

--- a/caramel/scripts/initializedb.py
+++ b/caramel/scripts/initializedb.py
@@ -15,17 +15,23 @@ from caramel.models import init_session
 
 def cmdline():
     parser = argparse.ArgumentParser()
+
     config.add_inifile_argument(parser)
     config.add_db_url_argument(parser)
+    config.add_verbosity_argument(parser)
+
     args = parser.parse_args()
     return args
 
 
 def main():
     args = cmdline()
-    config_uri = args.inifile
-    setup_logging(config_uri)
-    settings = get_appsettings(config_uri)
+    config_path = args.inifile
+    settings = get_appsettings(config_path)
+
+    setup_logging(config_path)
+    config.configure_log_level(args)
+
     db_url = config.get_db_url(args, settings)
     engine = create_engine(db_url)
     init_session(engine, create=True)


### PR DESCRIPTION
Implementation of the underlying logic to set the verbosity of a tool/scripts root logger from the command line as flags( "-vvv") or as an environment variable(CARAMEL_LOG_LEVEL=[0:3]). configure_log_level assumes that loggers have been set up from a config file before being called. Requested in issue #55