### PR TITLE
Add databse-URL setting logic

### DIFF
--- a/caramel/config.py
+++ b/caramel/config.py
@@ -2,6 +2,7 @@
 # vim: expandtab shiftwidth=4 softtabstop=4 tabstop=17 filetype=python :
 """caramel.config is a helper library that standardizes and collects the logic
  in one place used by the caramel CLI tools/scripts"""
+
 import argparse
 import os
 
@@ -20,6 +21,15 @@ def add_inifile_argument(parser, env=None):
         default=default_ini,
         type=str,
         action=CheckInifilePathSet,
+    )
+
+
+def add_db_url_argument(parser, env=None):
+    """Adds an argument for the URL for the database to a given parser"""
+    parser.add_argument(
+        "--dburl",
+        help="URL to the database to use",
+        type=str,
     )
 
 
@@ -71,3 +81,15 @@ def _get_config_value(
             env_var,
         )
     return result
+
+
+def get_db_url(arguments=None, settings=None, required=True):
+    """Returns URL to use for database, prefer argument > env-variable >
+    config-file"""
+    return _get_config_value(
+        arguments,
+        variable="dburl",
+        required=required,
+        setting_name="sqlalchemy.url",
+        settings=settings,
+    )

--- a/caramel/scripts/autosign.py
+++ b/caramel/scripts/autosign.py
@@ -82,6 +82,7 @@ def cmdline():
     """Basically just parsing the arguments and returning them"""
     parser = argparse.ArgumentParser()
     config.add_inifile_argument(parser)
+    config.add_db_url_argument(parser)
     parser.add_argument("--delay", help="How long to sleep. (ms)")
     parser.add_argument("--valid", help="How many hours the certificate is valid for")
     args = parser.parse_args()
@@ -102,7 +103,8 @@ def main():
     args = cmdline()
     env = bootstrap(args.inifile)
     settings, closer = env["registry"].settings, env["closer"]
-    engine = create_engine(settings["sqlalchemy.url"])
+    db_url = config.get_db_url(args, settings)
+    engine = create_engine(db_url)
     models.init_session(engine)
     delay = int(settings.get("delay", 500)) / 1000
     valid = int(settings.get("valid", 3))

--- a/caramel/scripts/initializedb.py
+++ b/caramel/scripts/initializedb.py
@@ -2,7 +2,7 @@
 # vim: expandtab shiftwidth=4 softtabstop=4 tabstop=17 filetype=python :
 import argparse
 
-from sqlalchemy import engine_from_config
+from sqlalchemy import create_engine
 
 from pyramid.paster import (
     get_appsettings,
@@ -16,6 +16,7 @@ from caramel.models import init_session
 def cmdline():
     parser = argparse.ArgumentParser()
     config.add_inifile_argument(parser)
+    config.add_db_url_argument(parser)
     args = parser.parse_args()
     return args
 
@@ -25,5 +26,6 @@ def main():
     config_uri = args.inifile
     setup_logging(config_uri)
     settings = get_appsettings(config_uri)
-    engine = engine_from_config(settings, "sqlalchemy.")
+    db_url = config.get_db_url(args, settings)
+    engine = create_engine(db_url)
     init_session(engine, create=True)

--- a/caramel/scripts/tool.py
+++ b/caramel/scripts/tool.py
@@ -18,6 +18,7 @@ import concurrent.futures
 def cmdline():
     parser = argparse.ArgumentParser()
     config.add_inifile_argument(parser)
+    config.add_db_url_argument(parser)
     parser.add_argument(
         "--long",
         help="Generate a long lived cert(1 year)",
@@ -195,7 +196,8 @@ def main():
     args = cmdline()
     env = bootstrap(args.inifile)
     settings, closer = env["registry"].settings, env["closer"]
-    engine = create_engine(settings["sqlalchemy.url"])
+    db_url = config.get_db_url(args, settings)
+    engine = create_engine(db_url)
     models.init_session(engine)
     settings_backdate = asbool(settings.get("backdate", False))
 


### PR DESCRIPTION
Implementation of the underlying logic to set the URL of the database as a command line argument, environment variable(CARAMEL_DB_URL=/my/url) or the config-file, in that priority. Requested in issue #55