### PR TITLE
General function for where a config value should be read

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -51,3 +51,126 @@ class TestConfig(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             parser.parse_args([])
+
+
+class TestGetConfigValue(unittest.TestCase):
+    """Tests for caramel.config._get_config_value"""
+
+    def test_argument_only(self):
+        """Test that a value will be returned even without settings or an
+        env-variable"""
+        variable_value = "very important configuration detail"
+        variable_name = "my-var"
+        arguments = argparse.Namespace()
+        setattr(arguments, variable_name, variable_value)
+        value = config._get_config_value(arguments, variable_name, env={})
+        self.assertEqual(variable_value, value)
+
+    def test_argument_preferred(self):
+        """Test to see that argument value is preferred when the variable exists in
+        settings and environment as well"""
+        variable_name = "my-var"
+        arg_value = "The best stuff around"
+        env_name = "CARAMEL_MY_VAR"
+
+        arguments = argparse.Namespace()
+        setattr(arguments, variable_name, arg_value)
+        value = config._get_config_value(
+            arguments,
+            variable_name,
+            settings={variable_name: "The worstest"},
+            env={env_name: "The worst stuff"},
+        )
+        self.assertEqual(arg_value, value)
+
+    def test_env_preferred(self):
+        """Test to see that env value is preferred when the variable exists in
+        settings as well"""
+        variable_name = "my-var"
+        env_value = "The best stuff around"
+        env_name = "CARAMEL_MY_VAR"
+        arguments = argparse.Namespace()
+        setattr(arguments, variable_name, None)
+        value = config._get_config_value(
+            arguments,
+            variable_name,
+            settings={variable_name: "The worstest"},
+            env={env_name: env_value},
+        )
+        self.assertEqual(env_value, value)
+
+    def test_settings_only(self):
+        """Test to see that the value from settings is returned when no argument or
+        env-variable"""
+        variable_name = "my-var"
+        settings_value = "Come on Toshi, you're sooo good"
+        arguments = argparse.Namespace()
+        setattr(arguments, variable_name, None)
+        value = config._get_config_value(
+            arguments,
+            variable_name,
+            settings={variable_name: settings_value},
+            env={},
+        )
+        self.assertEqual(settings_value, value)
+
+    def test_settings_only_no_argument(self):
+        """Test to see that the value from settings is returned when variable is not
+        settable from the commandline and no env-variable"""
+        variable_name = "my-var"
+        settings_value = "Come on Toshi, you're sooo good"
+        arguments = argparse.Namespace()
+        value = config._get_config_value(
+            arguments,
+            variable_name,
+            settings={variable_name: settings_value},
+            env={},
+        )
+        self.assertEqual(settings_value, value)
+
+    def test_different_setting_name_only(self):
+        """Test to see that the value from settings is returned when the name of the
+        settings differs from the varaible name"""
+        variable_name = "my-var"
+        setting_name = "something.very.different"
+        settings_value = "Come on Toshi, you're sooo good"
+        arguments = argparse.Namespace()
+        setattr(arguments, variable_name, None)
+        value = config._get_config_value(
+            arguments,
+            variable_name,
+            setting_name=setting_name,
+            settings={setting_name: settings_value},
+            env={},
+        )
+        self.assertEqual(settings_value, value)
+
+    def test_nothing(self):
+        """Test to see that if no value has been supplied as either an argument,
+        environment-variable or setting it returns None"""
+        variable_name = "my-var"
+        arguments = argparse.Namespace()
+        setattr(arguments, variable_name, None)
+        value = config._get_config_value(
+            arguments,
+            variable_name,
+            settings={},
+            env={},
+        )
+        self.assertEqual(None, value)
+
+    def test_requierd_nothing(self):
+        """Test to see that if no value has been supplied as either an argument,
+        environment-variable or setting and the variable is required a ValueError
+         will be raised"""
+        variable_name = "my-var"
+        arguments = argparse.Namespace()
+        setattr(arguments, variable_name, None)
+        with self.assertRaises(ValueError):
+            config._get_config_value(
+                arguments,
+                variable_name,
+                required=True,
+                settings={},
+                env={},
+            )


### PR DESCRIPTION
A semi-private function for getting a config variable, meant to be wrapped for usage outside caramel.config. E.g.:

```
def get_a(arguments):
    return _get_config_value( arguments, "a", True)
```

It also helps with handling if a config variable should be required so ArgParses required argument is not needed, not limiting the requirement to only the argument.