### PR TITLE
Add ca-cert/key setting logic

### DIFF
--- a/caramel/config.py
+++ b/caramel/config.py
@@ -53,6 +53,20 @@ def add_verbosity_argument(parser):
     )
 
 
+def add_ca_arguments(parser):
+    """Adds a ca-cert and ca-key argument to a given parser"""
+    parser.add_argument(
+        "--ca-cert",
+        help="Path to CA certificate to use",
+        type=str,
+    )
+    parser.add_argument(
+        "--ca-key",
+        help="Path to CA key to use",
+        type=str,
+    )
+
+
 class CheckInifilePathSet(argparse.Action):
     """An arparse.Action to raise an error if no config file has been
     defined by the user or  in the environment"""
@@ -140,3 +154,22 @@ def configure_log_level(arguments: argparse.Namespace, logger=None):
     if logger is None:
         logger = logging.getLogger()
     logger.setLevel(log_level)
+
+
+def get_ca_cert_key_path(arguments: argparse.Namespace, settings=None, required=True):
+    """Returns the path to the ca-cert and ca-key to use"""
+    ca_cert_path = _get_config_value(
+        arguments,
+        variable="ca-cert",
+        required=required,
+        setting_name="ca.cert",
+        settings=settings,
+    )
+    ca_key_path = _get_config_value(
+        arguments,
+        variable="ca-key",
+        required=required,
+        setting_name="ca.key",
+        settings=settings,
+    )
+    return ca_cert_path, ca_key_path

--- a/caramel/scripts/autosign.py
+++ b/caramel/scripts/autosign.py
@@ -89,6 +89,7 @@ def cmdline():
     config.add_inifile_argument(parser)
     config.add_db_url_argument(parser)
     config.add_verbosity_argument(parser)
+    config.add_ca_arguments(parser)
 
     parser.add_argument("--delay", help="How long to sleep. (ms)")
     parser.add_argument("--valid", help="How many hours the certificate is valid for")
@@ -125,11 +126,10 @@ def main():
     del valid
 
     try:
-        certname = settings["ca.cert"]
-        keyname = settings["ca.key"]
-    except KeyError:
-        error_out("config file needs ca.cert and ca.key properly set", closer)
-    ca = models.SigningCert.from_files(certname, keyname)
+        ca_cert_path, ca_key_path = config.get_ca_cert_key_path(args, settings)
+    except ValueError as error:
+        error_out(str(error), closer)
+    ca = models.SigningCert.from_files(ca_cert_path, ca_key_path)
     mainloop(delay, ca, delta)
 
 

--- a/caramel/scripts/tool.py
+++ b/caramel/scripts/tool.py
@@ -17,8 +17,11 @@ import concurrent.futures
 
 def cmdline():
     parser = argparse.ArgumentParser()
+
     config.add_inifile_argument(parser)
     config.add_db_url_argument(parser)
+    config.add_ca_arguments(parser)
+
     parser.add_argument(
         "--long",
         help="Generate a long lived cert(1 year)",
@@ -208,11 +211,11 @@ def main():
     del _short, _long
 
     try:
-        certname = settings["ca.cert"]
-        keyname = settings["ca.key"]
-    except KeyError:
-        error_out("config file needs ca.cert and ca.key properly set")
-    ca = models.SigningCert.from_files(certname, keyname)
+        ca_cert_path, ca_key_path = config.get_ca_cert_key_path(args, settings)
+    except ValueError as error:
+        error_out(str(error))
+
+    ca = models.SigningCert.from_files(ca_cert_path, ca_key_path)
 
     if life_short > life_long:
         error_out(


### PR DESCRIPTION
Implementation of the underlying logic to set the ca-cer/key to use as a command line argument(--ca-cert, --ca-cert), environment variable(CARAMEL_CA_CERT=/my/cert, CARAMEL_CA_KEY=/my/key) or the config-file(ca.cert, ca.key), in that priority. Requested in issue #55