### PR TITLE
System test to see if caramel is runable

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,6 +30,7 @@ caramel:test:
     - pip3 install .
   script:
     - python3 -m unittest discover
+    - make systest
 
 rebase:test:
   extends: .rebase

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,156 @@
+#Python3 and virtual environment
+VENV := $(shell mktemp -d)
+PYTHON3 := $(VENV)/bin/python3
+
+# PIDs of background processes
+SERVER_PID := $(VENV)/server.pid
+AUTOSIGN_PID := $(VENV)/autosign.pid
+
+# Database and CA cert and key for caramel server to use
+DB_FILE := $(VENV)/caramel.sqlite
+CA_CERT := $(VENV)/caramel.ca.cert
+CA_KEY := $(VENV)/caramel.ca.key
+
+# client.crt will be generated if the server correctly gives our stored CSR back
+CLIENT_CERT := $(VENV)/client.crt
+
+# If caramel_tool exists in the venv caramel has been installed
+CARAMEL_TOOL := $(VENV)/bin/caramel_tool
+
+# Terminal formatting
+BOLD := tput bold
+PASS := $(BOLD); tput setaf 2
+FAIL := $(BOLD); tput setaf 1
+LINE := echo "---------------------------------------"
+RESET_TERM := tput op; tput sgr0
+BLR := $(BOLD); $(LINE); $(RESET_TERM) #Bold Line, Reset formatting
+
+#Check for python3 install and virtual environment
+$(PYTHON3):
+	@if [ -z python3 ]; then \
+		$(FAIL);\
+		echo "Python 3 could not be found.";\
+		$(RESET_TERM);\
+		exit 2; \
+	fi
+	@$(BOLD); echo "Create a new venv for testing at $(VENV)";\
+	$(BLR);
+	python3 -m venv $(VENV)
+	@$(BLR)
+
+
+#Install the project via setup.py
+.PHONEY: venv-install
+venv-install: $(CARAMEL_TOOL)
+$(CARAMEL_TOOL): $(PYTHON3) setup.py
+	@$(BOLD); echo "Install caramel and its dependencies in venv: $(VENV)";\
+	$(BLR);
+	$(VENV)/bin/pip3 install -e .
+	@$(BLR)
+
+# Create a sqlite-db configured for use with caramel
+$(DB_FILE): $(CARAMEL_TOOL)
+	@$(BOLD); echo "Create a new DB at $(DB_FILE)";\
+	$(BLR);
+	$(VENV)/bin/caramel_initialize_db
+	@$(BLR)
+
+# Generate a new CA cert and key pair
+$(CA_CERT): $(CARAMEL_TOOL)
+	@$(BOLD); echo "Generate new CA cert and key with tests/ca_test_input.txt";\
+	$(BLR)
+	$(VENV)/bin/caramel_ca < tests/ca_test_input.txt
+	@$(BLR)
+
+# Start caramel using pserve in the background, save PID to SERVER_PID
+$(SERVER_PID): $(CA_CERT) $(DB_FILE)
+	@ $(BOLD); echo "Start new caramel server in the background, sleep 2s to \
+	give it time to start";\
+	$(BLR)
+	setsid $(VENV)/bin/pserve tests/caramel_launcher.ini \
+		ca_cert=$(CARAMEL_CA_CERT) \
+		ca_key=$(CARAMEL_CA_KEY) \
+		http_port=6543 \
+		http_host=127.0.0.1 \
+		life_short=48 \
+		life_long=720 \
+		dburl=$(CARAMEL_DBURL) \
+		log_level=INFO\
+		>/dev/null 2>&1 < /dev/null & \
+	echo $$! > $(SERVER_PID)
+	sleep 2s
+	@$(BLR)
+
+# Start caramel_autosign in the background, save PID to AUTOSIGN_PID
+$(AUTOSIGN_PID): $(CARAMEL_TOOL) $(CA_CERT) $(DB_FILE)
+	@$(BOLD);echo "Start new caramel_autosign in the background";\
+	$(BLR)
+	setsid $(VENV)/bin/caramel_autosign >/dev/null 2>&1 < /dev/null &\
+	echo $$! > $(AUTOSIGN_PID)
+	@$(BLR)
+
+# Try to upload a CSR to a caramel server and then confirm our CSR was stored
+$(CLIENT_CERT): $(SERVER_PID) $(AUTOSIGN_PID)
+	@ $(BOLD); echo "Use client-example.sh to upload our CSR, wait for it to \
+	get processed, then call it again to confirm the server stored our CSR";\
+	$(BLR)
+	chmod +x client-example.sh
+	./client-example.sh $(VENV)
+	sleep 2s
+	./client-example.sh $(VENV)
+	@$(BLR)
+
+# Basic tests that caramel can be installed and run with test data,
+# using environment variables for config
+.PHONEY: systest
+systest: export CARAMEL_INI = development.ini
+systest: export CARAMEL_DBURL = sqlite:///$(DB_FILE)
+systest: export CARAMEL_CA_CERT = $(CA_CERT)
+systest: export CARAMEL_CA_KEY = $(CA_KEY)
+systest: export CARAMEL_CA = 127.0.0.1:6543
+systest: export CARAMEL_LOG_LEVEL = 0
+systest: $(CLIENT_CERT)
+	@kill $(shell cat $(SERVER_PID));\
+	if [ $$? -eq 0 ]; then \
+		$(PASS); $(LINE);\
+		echo "Caramel server started and terminated successfully";\
+	else \
+		$(FAIL); $(LINE);\
+		echo "System test failed: Caramel server exited before termination with\
+		 exit code: $$?";\
+		exit 1;\
+	fi;
+	@$(BLR)
+
+	@kill $(shell cat $(AUTOSIGN_PID));\
+	if [ $$? -eq 0 ]; then \
+		$(PASS); $(LINE);\
+		echo "Autosign server started and terminated successfully";\
+	else \
+		$(FAIL); $(LINE);\
+		echo "System test failed: Autosign server exited before terminated with\
+		 exit code: $$?";\
+		exit 1;\
+	fi;
+	@$(BLR)
+
+	@if [ -f $(CLIENT_CERT) ]; then \
+		$(PASS); $(LINE);\
+		echo "System test passed: Caramel successfully registered our CSR";\
+	else \
+		$(FAIL); $(LINE);\
+		echo "System test failed: Something went wrong when communicating with \
+		the server";\
+		exit 1;\
+	fi;\
+	$(BLR)
+
+
+# Removes the virtual environment created via this makefile,
+# NOTE: since venv is a temporary directory, this will only remove files if
+# 		run after a target, e.g. "make systest clean"
+.PHONEY: clean
+clean:
+	@echo "Removing local test virtual environment"; $(BLR)
+	rm -rf $(VENV)
+	@$(BLR)

--- a/tests/ca_test_input.txt
+++ b/tests/ca_test_input.txt
@@ -1,0 +1,5 @@
+SE
+Östergötland
+Linköping
+Muppar AB
+Muppar Teknik

--- a/tests/caramel_launcher.ini
+++ b/tests/caramel_launcher.ini
@@ -1,0 +1,80 @@
+###
+# app configuration
+# http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/environment.html
+###
+[app:main]
+use = egg:caramel
+
+# Point the following two settings on where you want your CA certificate & Key to live
+ca.cert = %(ca_cert)s
+ca.key = %(ca_key)s
+
+# This causes all certs to be backdated to the age of the start cert.
+# This is an ugly workaround for our embedded systems that lack RTC.
+backdate = False
+# Default to 48 hour certs
+lifetime.short = %(life_short)s
+# Long term certs are for 30 days
+lifetime.long = %(life_long)s
+
+
+# Change this to match your database
+# http://docs.sqlalchemy.org/en/rel_0_9/core/engines.html#database-urls
+sqlalchemy.url = %(dburl)s
+
+
+pyramid.reload_templates = true
+pyramid.debug_authorization = false
+pyramid.debug_notfound = false
+pyramid.debug_routematch = false
+pyramid.default_locale_name = en
+pyramid.includes =
+    pyramid_tm
+
+###
+# wsgi server configuration
+###
+[server:main]
+use = egg:waitress#main
+host = %(http_host)s
+port = %(http_port)s
+
+###
+# logging configuration
+# http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/logging.html
+###
+
+[loggers]
+keys = root, caramel, sqlalchemy
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = %(log_level)s
+handlers = console
+
+[logger_caramel]
+level = DEBUG
+handlers =
+qualname = caramel
+
+[logger_sqlalchemy]
+level = INFO
+handlers =
+qualname = sqlalchemy.engine
+# "level = INFO" logs SQL queries.
+# "level = DEBUG" logs SQL queries and results.
+# "level = WARN" logs neither.  (Recommended for production systems.)
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s

--- a/tests/caramel_launcher.sh
+++ b/tests/caramel_launcher.sh
@@ -1,0 +1,12 @@
+#! /bin/sh
+## Launch caramel with pserve as a Pyramid WSGI app using environment variables
+## for configuration
+pserve caramel_launcher.ini \
+  ca_cert="${CARAMEL_CA_CERT:-${BASEDIR}/example/caramel.ca.cert}" \
+  ca_key="${CARAMEL_CA_KEY:-${BASEDIR}/example/caramel.ca.key}" \
+  http_port="${CARAMEL_PORT:-6543}" \
+  http_host="${CARAMEL_HOST:-127.0.0.1}" \
+  life_short="${CARAMEL_LIFE_SHORT:-48}" \
+  life_long="${CARAMEL_LIFE_LONG:-720}" \
+  dburl="${CARAMEL_DBURL:-sqlite:///${BASEDIR}/caramel.sqlite}" \
+  log_level="${CARAMEL_LOG_LEVEL:-INFO}"


### PR DESCRIPTION
Adding a Makefile that handles the setup and execution of a "complete" system test,
ensuring that caramel can be installed and run on the machine. To conduct the
test it first generate a new CA cert+key using caramel_ca with
tests/ca_test_input.txt, then a new database is initialized with
caramel_initialize_db. After the setup is complete the server is started in the
background with the generated files, the same is then done for caramel_autosign.
After that use client-example.sh to first upload a CSR, then again to check if
the server has processed our CSR, in which case we should have a file
client.csr, if not something has gone wrong. Any failiur to pass stages of the
test results in exitcode 1.

make venv-install : setup a virtual environment(mktemp -d), install caramel here
make systest : run the system test, will install caramel if not already done
make clean : removes the virtual environment(mktemp -d)

Based on #67 