### PR TITLE
Add launcher that use env-vars for conf 

### DIFF
--- a/tests/caramel_launcher.ini
+++ b/tests/caramel_launcher.ini
@@ -1,0 +1,80 @@
+###
+# app configuration
+# http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/environment.html
+###
+[app:main]
+use = egg:caramel
+
+# Point the following two settings on where you want your CA certificate & Key to live
+ca.cert = %(ca_cert)s
+ca.key = %(ca_key)s
+
+# This causes all certs to be backdated to the age of the start cert.
+# This is an ugly workaround for our embedded systems that lack RTC.
+backdate = False
+# Default to 48 hour certs
+lifetime.short = %(life_short)s
+# Long term certs are for 30 days
+lifetime.long = %(life_long)s
+
+
+# Change this to match your database
+# http://docs.sqlalchemy.org/en/rel_0_9/core/engines.html#database-urls
+sqlalchemy.url = %(dburl)s
+
+
+pyramid.reload_templates = true
+pyramid.debug_authorization = false
+pyramid.debug_notfound = false
+pyramid.debug_routematch = false
+pyramid.default_locale_name = en
+pyramid.includes =
+    pyramid_tm
+
+###
+# wsgi server configuration
+###
+[server:main]
+use = egg:waitress#main
+host = %(http_host)s
+port = %(http_port)s
+
+###
+# logging configuration
+# http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/logging.html
+###
+
+[loggers]
+keys = root, caramel, sqlalchemy
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = %(log_level)s
+handlers = console
+
+[logger_caramel]
+level = DEBUG
+handlers =
+qualname = caramel
+
+[logger_sqlalchemy]
+level = INFO
+handlers =
+qualname = sqlalchemy.engine
+# "level = INFO" logs SQL queries.
+# "level = DEBUG" logs SQL queries and results.
+# "level = WARN" logs neither.  (Recommended for production systems.)
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s

--- a/tests/caramel_launcher.sh
+++ b/tests/caramel_launcher.sh
@@ -1,0 +1,12 @@
+#! /bin/sh
+## Launch caramel with pserve as a Pyramid WSGI app using environment variables
+## for configuration
+pserve caramel_launcher.ini \
+  ca_cert="${CARAMEL_CA_CERT:-${BASEDIR}/example/caramel.ca.cert}" \
+  ca_key="${CARAMEL_CA_KEY:-${BASEDIR}/example/caramel.ca.key}" \
+  http_port="${CARAMEL_PORT:-6543}" \
+  http_host="${CARAMEL_HOST:-127.0.0.1}" \
+  life_short="${CARAMEL_LIFE_SHORT:-48}" \
+  life_long="${CARAMEL_LIFE_LONG:-720}" \
+  dburl="${CARAMEL_DBURL:-sqlite:///${BASEDIR}/caramel.sqlite}" \
+  log_level="${CARAMEL_LOG_LEVEL:-INFO}"


### PR DESCRIPTION
Adds the POSIX-script caramel_launcher.sh that just starts caramel using pserve with the addition that it reads the environment for server configuration, using caramel_launcher.ini as a bypass for the need to set server configuration in an ini-file. Current env-vars are:

CARAMEL_CA_CERT : a path to a ca cert to use, default ${BASEDIR}/example/caramel.ca.cert
CARAMEL_CA_KEY : a path to a ca key to use, default ${BASEDIR}/example/caramel.ca.key
CARAMEL_PORT : port number for caramel server to use, default 6543
CARAMEL_HOST : address for caramel server to use, defualt 127.0.0.1
CARAMEL_LIFE_SHORT : the short lifetime for CSRs, default 48
CARAMEL_LIFE_LONG : the long lifetime for CSRs, default 720
CARAMEL_DBURL : URI to database to use, default sqlite:///${BASEDIR}/caramel.sqlite
CARAMEL_LOG_LEVEL : what level the root logger should be at, default INFO

~~Based on branch #66~~, related to issue #55