### PR TITLE
Add lifetime and backdate logic for config

### DIFF
--- a/caramel/config.py
+++ b/caramel/config.py
@@ -67,6 +67,32 @@ def add_ca_arguments(parser):
     )
 
 
+def add_lifetime_arguments(parser):
+    """Adds an argument for the short and long lifetime of certs"""
+    parser.add_argument(
+        "-l",
+        "--life-short",
+        help="Lifetime of short term certs",
+        type=int,
+    )
+    parser.add_argument(
+        "-s",
+        "--life-long",
+        help="Lifetime of long term certs",
+        type=int,
+    )
+
+
+def add_backdate_argument(parser):
+    """Adds an argument to enable backdating certs"""
+    parser.add_argument(
+        "-b",
+        "--backdate",
+        help="Use backdating, default is False",
+        action="store_true",
+    )
+
+
 class CheckInifilePathSet(argparse.Action):
     """An arparse.Action to raise an error if no config file has been
     defined by the user or  in the environment"""
@@ -178,3 +204,44 @@ def get_ca_cert_key_path(arguments: argparse.Namespace, settings=None, required=
         settings=settings,
     )
     return ca_cert_path, ca_key_path
+
+
+def get_lifetime_short(
+    arguments: argparse.Namespace, settings=None, required=False, default=None
+):
+    """Returns the default lifetime for certs in hours"""
+    return _get_config_value(
+        arguments,
+        variable="life-short",
+        required=required,
+        setting_name="lifetime.short",
+        settings=settings,
+        default=default,
+    )
+
+
+def get_lifetime_long(
+    arguments: argparse.Namespace, settings=None, required=False, default=None
+):
+    """Returns the long term certs lifetime in hours"""
+    return _get_config_value(
+        arguments,
+        variable="life-long",
+        required=required,
+        setting_name="lifetime.long",
+        settings=settings,
+        default=default,
+    )
+
+
+def get_backdate(
+    arguments: argparse.Namespace, settings=None, required=False, default=None
+):
+    """Returns the long term certs lifetime in hours"""
+    return _get_config_value(
+        arguments,
+        variable="backdate",
+        required=required,
+        settings=settings,
+        default=default,
+    )

--- a/caramel/config.py
+++ b/caramel/config.py
@@ -89,10 +89,12 @@ def _get_config_value(
     required=False,
     setting_name=None,
     settings=None,
+    default=None,
     env=None,
 ):
     """Returns what value to use for a given config variable, prefer argument >
-    env-variable > config-file"""
+    env-variable > config-file, if a value cant be found and default is not
+    None, default is returned"""
     result = None
     if setting_name is None:
         setting_name = variable
@@ -106,6 +108,9 @@ def _get_config_value(
 
     arg_value = getattr(arguments, variable, result)
     result = arg_value if arg_value is not None else result
+
+    if result is None:
+        result = default
 
     if required and result is None:
         raise ValueError(

--- a/caramel/scripts/tool.py
+++ b/caramel/scripts/tool.py
@@ -21,6 +21,8 @@ def cmdline():
     config.add_inifile_argument(parser)
     config.add_db_url_argument(parser)
     config.add_ca_arguments(parser)
+    config.add_backdate_argument(parser)
+    config.add_lifetime_arguments(parser)
 
     parser.add_argument(
         "--long",
@@ -202,10 +204,10 @@ def main():
     db_url = config.get_db_url(args, settings)
     engine = create_engine(db_url)
     models.init_session(engine)
-    settings_backdate = asbool(settings.get("backdate", False))
+    settings_backdate = asbool(config.get_backdate(args, settings, default=False))
 
-    _short = int(settings.get("lifetime.short", 48))
-    _long = int(settings.get("lifetime.long", 7 * 24))
+    _short = int(config.get_lifetime_short(args, settings, default=48))
+    _long = int(config.get_lifetime_long(args, settings, default=7 * 24))
     life_short = calc_lifetime(relativedelta(hours=_short))
     life_long = calc_lifetime(relativedelta(hours=_long))
     del _short, _long


### PR DESCRIPTION
Functions for adding lifetime(short  and long) and backdate as arguments to the commandline and choosing what source to use for configuration(argument > environment > config-file). Currently caramel_tool supports this. Environmet variables are CARAMEL_LIFE_SHORT CARAMEL_LIFE_LONG, CARAMEL_BACKDATE.