### PR TITLE
 Docker: Add Dockerfile for caramel-tools 

### DIFF
--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -1,0 +1,12 @@
+FROM python:3.9-slim-buster as build
+COPY [".", "/build"]
+WORKDIR /wheel
+RUN pip3 install wheel
+RUN pip3 wheel --wheel-dir=/wheel /build
+
+FROM python:3.9-slim-buster as install
+COPY --from=build ["/wheel", "/wheel"]
+ENV CARAMEL_INI="/etc/caramel/caramel.ini"
+COPY ["minimal.ini", "${CARAMEL_INI}"]
+RUN pip3 install --no-index --find-links=/wheel caramel
+RUN rm -rf /wheel

--- a/minimal.ini
+++ b/minimal.ini
@@ -1,0 +1,70 @@
+###
+# NOTE: THIS IS ONLY FOR USE INSIDE CONTAINERS, SOME CONFIGURATION IS MISSING
+# HERE, FOR NORMAL TESTING USE development.ini
+# app configuration
+# http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/environment.html
+###
+[app:main]
+use = egg:caramel
+
+# Change this to match your database
+# http://docs.sqlalchemy.org/en/rel_0_9/core/engines.html#database-urls
+sqlalchemy.url = sqlite:////etc/caramel/caramel.sqlite
+
+
+
+pyramid.reload_templates = true
+pyramid.debug_authorization = false
+pyramid.debug_notfound = false
+pyramid.debug_routematch = false
+pyramid.default_locale_name = en
+pyramid.includes =
+    pyramid_tm
+
+###
+# wsgi server configuration
+###
+[server:main]
+use = egg:waitress#main
+host = localhost
+port = 6543
+
+###
+# logging configuration
+# http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/logging.html
+###
+
+[loggers]
+keys = root, caramel, sqlalchemy
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = INFO
+handlers = console
+
+[logger_caramel]
+level = DEBUG
+handlers =
+qualname = caramel
+
+[logger_sqlalchemy]
+level = INFO
+handlers =
+qualname = sqlalchemy.engine
+# "level = INFO" logs SQL queries.
+# "level = DEBUG" logs SQL queries and results.
+# "level = WARN" logs neither.  (Recommended for production systems.)
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s


### PR DESCRIPTION
Add a Dockerfile to be able to build a container from which caramel-tools can be run. To build the image docker can be called with for example:
docker build -t caramel_tools . -f Dockerfile.tools

To use caramel_tool in the new container docker can be called like so:
docker run caramel_tools caramel_tool --list

minimal.ini is a bare minimum config file that should only be used in
containers