### PR TITLE
Remove ini dependency for app

### DIFF
--- a/caramel/__init__.py
+++ b/caramel/__init__.py
@@ -13,6 +13,7 @@ def main(global_config, **settings):
     engine = engine_from_config(settings, "sqlalchemy.")
     init_session(engine)
     config = Configurator(settings=settings)
+    config.include("pyramid_tm")
     config.add_route("ca", "/root.crt", request_method="GET")
     config.add_route("cabundle", "/bundle.crt", request_method="GET")
     config.add_route("csr", "/{sha256:[0-9a-f]{64}}", request_method="POST")

--- a/caramel/__init__.py
+++ b/caramel/__init__.py
@@ -2,6 +2,7 @@
 # vim: expandtab shiftwidth=4 softtabstop=4 tabstop=17 filetype=python :
 from pyramid.config import Configurator
 from sqlalchemy import engine_from_config
+from .config import get_db_url
 
 from .models import (
     init_session,
@@ -10,6 +11,7 @@ from .models import (
 
 def main(global_config, **settings):
     """This function returns a Pyramid WSGI application."""
+    settings["sqlalchemy.url"] = get_db_url(settings=settings)
     engine = engine_from_config(settings, "sqlalchemy.")
     init_session(engine)
     config = Configurator(settings=settings)

--- a/caramel/config.py
+++ b/caramel/config.py
@@ -5,7 +5,10 @@
 
 import argparse
 import logging
+from logging.config import dictConfig
 import os
+import pyramid.paster as paster
+from pyramid.scripting import prepare
 
 LOG_LEVEL = (
     logging.ERROR,
@@ -13,6 +16,38 @@ LOG_LEVEL = (
     logging.INFO,
     logging.DEBUG,
 )
+
+DEFAULT_LOGGING_CONFIG = {
+    "version": 1,
+    "formatters": {
+        "generic": {
+            "format": "%(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s]"
+            "%(message)s"
+        },
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "stream": "ext://sys.stderr",
+            "level": "NOTSET",
+            "formatter": "generic",
+        },
+    },
+    "loggers": {
+        "": {  # root logger
+            "handlers": ["console"],
+            "level": "INFO",
+        },
+        "caramel": {
+            "level": "DEBUG",
+            "qualname": "caramel",
+        },
+        "sqlalchemy": {
+            "level": "INFO",
+            "qualname": "sqlalchemy.engine",
+        },
+    },
+}
 
 
 def add_inifile_argument(parser, env=None):
@@ -245,3 +280,12 @@ def get_backdate(
         settings=settings,
         default=default,
     )
+
+
+def setup_logging(config_path=None):
+    """wrapper for pyramid.paster.sertup_logging using file at config.path, if
+    no config_path is passed on use dictionary DEFAULT_LOGGING_CONFIG"""
+    if config_path:
+        paster.setup_logging(config_path)
+    else:
+        dictConfig(DEFAULT_LOGGING_CONFIG)

--- a/caramel/config.py
+++ b/caramel/config.py
@@ -92,7 +92,6 @@ def add_inifile_argument(parser, env=None):
         dest="inifile",
         default=default_ini,
         type=str,
-        action=CheckInifilePathSet,
     )
 
 
@@ -155,22 +154,6 @@ def add_backdate_argument(parser):
         help="Use backdating, default is False",
         action="store_true",
     )
-
-
-class CheckInifilePathSet(argparse.Action):
-    """An arparse.Action to raise an error if no config file has been
-    defined by the user or  in the environment"""
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        setattr(namespace, self.dest, values)
-        inifile = getattr(namespace, self.dest, None)
-        if inifile is None:
-            raise ValueError(
-                "ENVIRONMENT VARIABLE 'CARAMEL_INI' IS NOT SET\n"
-                " - Set 'CARAMEL_INI' to the absolute path of the config or"
-                " specify a path in the call like so:\n"
-                "\t caramel_initializedb /path/to/config.ini [...]"
-            )
 
 
 def _get_config_value(

--- a/caramel/config.py
+++ b/caramel/config.py
@@ -49,6 +49,35 @@ DEFAULT_LOGGING_CONFIG = {
     },
 }
 
+DEFAULT_APP_SETTINGS = {
+    "csrf_trusted_origins": [],
+    "debug_all": False,
+    "debug_authorization": False,
+    "debug_notfound": False,
+    "debug_routematch": False,
+    "debug_templates": False,
+    "default_locale_name": "en",
+    "prevent_cachebust": False,
+    "prevent_http_cache": False,
+    "pyramid.csrf_trusted_origins": [],
+    "pyramid.debug_all": False,
+    "pyramid.debug_authorization": False,
+    "pyramid.debug_notfound": False,
+    "pyramid.debug_routematch": False,
+    "pyramid.debug_templates": False,
+    "pyramid.default_locale_name": "en",
+    "pyramid.prevent_cachebust": False,
+    "pyramid.prevent_http_cache": False,
+    "pyramid.reload_all": False,
+    "pyramid.reload_assets": False,
+    "pyramid.reload_resources": False,
+    "pyramid.reload_templates": True,
+    "reload_all": False,
+    "reload_assets": False,
+    "reload_resources": False,
+    "reload_templates": True,
+}
+
 
 def add_inifile_argument(parser, env=None):
     """Adds an argument to the parser for the config-file, defaults to
@@ -289,3 +318,18 @@ def setup_logging(config_path=None):
         paster.setup_logging(config_path)
     else:
         dictConfig(DEFAULT_LOGGING_CONFIG)
+
+
+def bootstrap(config_path=None):
+    """wrapper for pyramid.paster.bootstraper, if a config_path is not given
+    then DEFAULT_APP_SETTINGS to bootstrap the app manually"""
+    if config_path:
+        return paster.bootstrap(config_path)
+    else:
+        from caramel import main as get_app
+
+        app = get_app({}, **DEFAULT_APP_SETTINGS)
+        env = prepare()
+        env["app"] = app
+        return env
+

--- a/caramel/config.py
+++ b/caramel/config.py
@@ -333,3 +333,11 @@ def bootstrap(config_path=None):
         env["app"] = app
         return env
 
+
+def get_appsettings(config_path):
+    """wrapper for pyramid.paster.get_appsettings, if a config_path is not
+    given then return DEFAULT_APP_SETTINGS"""
+    if config_path:
+        return paster.get_appsettings(config_path)
+    else:
+        return DEFAULT_APP_SETTINGS

--- a/caramel/scripts/autosign.py
+++ b/caramel/scripts/autosign.py
@@ -32,9 +32,11 @@ import time
 import uuid
 import concurrent.futures
 
+from caramel.config import (
+    setup_logging,
+)
 from pyramid.paster import (
     bootstrap,
-    setup_logging,
 )
 
 from sqlalchemy import create_engine

--- a/caramel/scripts/autosign.py
+++ b/caramel/scripts/autosign.py
@@ -34,8 +34,6 @@ import concurrent.futures
 
 from caramel.config import (
     setup_logging,
-)
-from pyramid.paster import (
     bootstrap,
 )
 

--- a/caramel/scripts/generate_ca.py
+++ b/caramel/scripts/generate_ca.py
@@ -8,8 +8,6 @@ import os
 import OpenSSL.crypto as _crypto
 from caramel.config import (
     setup_logging,
-)
-from pyramid.paster import (
     bootstrap,
 )
 from caramel import config

--- a/caramel/scripts/generate_ca.py
+++ b/caramel/scripts/generate_ca.py
@@ -6,9 +6,11 @@ import argparse
 import uuid
 import os
 import OpenSSL.crypto as _crypto
+from caramel.config import (
+    setup_logging,
+)
 from pyramid.paster import (
     bootstrap,
-    setup_logging,
 )
 from caramel import config
 

--- a/caramel/scripts/initializedb.py
+++ b/caramel/scripts/initializedb.py
@@ -3,10 +3,11 @@
 import argparse
 
 from sqlalchemy import create_engine
-
+from caramel.config import (
+    setup_logging,
+)
 from pyramid.paster import (
     get_appsettings,
-    setup_logging,
 )
 
 import caramel.config as config

--- a/caramel/scripts/initializedb.py
+++ b/caramel/scripts/initializedb.py
@@ -4,10 +4,8 @@ import argparse
 
 from sqlalchemy import create_engine
 from caramel.config import (
-    setup_logging,
-)
-from pyramid.paster import (
     get_appsettings,
+    setup_logging,
 )
 
 import caramel.config as config

--- a/caramel/scripts/tool.py
+++ b/caramel/scripts/tool.py
@@ -4,7 +4,7 @@
 import argparse
 
 from caramel import config
-from pyramid.paster import bootstrap
+from caramel.config import bootstrap
 from pyramid.settings import asbool
 from sqlalchemy import create_engine
 from dateutil.relativedelta import relativedelta

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -45,14 +45,6 @@ class TestConfig(unittest.TestCase):
 
         self.assertEqual(args.inifile, my_ini)
 
-    def test_no_ini_path(self):
-        """no path in either argument or evironment, should raise ValueError"""
-        parser = argparse.ArgumentParser()
-        config.add_inifile_argument(parser, {})
-
-        with self.assertRaises(ValueError):
-            parser.parse_args([])
-
 
 class TestGetConfigValue(unittest.TestCase):
     """Tests for caramel.config._get_config_value"""


### PR DESCRIPTION
Removes the last dependencies on a .ini-file for running the scripts, hopefully closing #55. The setting to include pyramid_tm is moved from .ini-files to caramel.main, a setting the user should never need to change. 

If a .ini-file is not supplied, a default configuration is used to start the app and the setup of loggers is done from a default configuration.

Note: The server still uses .ini-file, at least when using pserve.