### PR TITLE
Gitlab-ci deprecation warning as error

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,7 @@ caramel:test:
   before_script:
     - pip3 install .
   script:
-    - python3 -m unittest discover
+    - python3 -W error::DeprecationWarning -m unittest discover
 
 caramel:systest:
   stage: test


### PR DESCRIPTION
Run unit-tests with deprecation warnings treated as errors so we can fix them before they turn into hard errors (might be as simple as using pytest with the right command line flag)

Based on #70 