### PR TITLE
Readjust CI rules to make the CI piplines work on GitHub pull requests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,6 +30,13 @@ caramel:test:
     - pip3 install .
   script:
     - python3 -m unittest discover
+
+caramel:systest:
+  stage: test
+  image: ${BUILD_IMAGE}
+  before_script:
+    - pip3 install .
+  script:
     - make systest
 
 rebase:test:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,7 +25,6 @@ stages:
 
 caramel:test:
   stage: test
-  when: always
   image: ${PYTHON_IMAGE}
   before_script:
     - pip3 install .
@@ -47,7 +46,6 @@ rebase:test:
 
 caramel:black:
   stage: test
-  when: always
   image: ${PYTHON_IMAGE}
   before_script:
     - pip3 install black
@@ -56,7 +54,6 @@ caramel:black:
 
 caramel:flake:
   stage: test
-  when: always
   image: ${PYTHON_IMAGE}
   before_script:
     - pip3 install flake8

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,13 +10,14 @@ include:
       - /ci/rebase.yml
 
 workflow:
-  # Similar to "Branch pipelines" definition,
-  # but with an exception of "push" to avoid duplicates
+  # Similar to "MergeRequest-Pipelines" default template.
+  # Adds extra "EXTERNAL_PULL_REQUEST_IID"
+  # see: https://gitlab.com/gitlab-org/gitlab/-/blob/master/lib/gitlab/ci/templates/Workflows/MergeRequest-Pipelines.gitlab-ci.yml
   rules:
-    - if: '$CI_PIPELINE_SOURCE == "push"'
-      when: never
+    - if: $CI_MERGE_REQUEST_IID
+    - if: $CI_EXTERNAL_PULL_REQUEST_IID
     - if: $CI_COMMIT_TAG
-    - if: $CI_COMMIT_BRANCH
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
 
 stages:
   - test


### PR DESCRIPTION
This adds new rules for the workflow to only cause a single MR pipeline to trigger.

it also fixes the tests to run in the correct image, and drops the "when" flags as it has been deprecated.
