### PR TITLE
Bug fixes for argument handling

### DIFF
--- a/caramel/config.py
+++ b/caramel/config.py
@@ -238,14 +238,14 @@ def get_ca_cert_key_path(arguments: argparse.Namespace, settings=None, required=
     """Returns the path to the ca-cert and ca-key to use"""
     ca_cert_path = _get_config_value(
         arguments,
-        variable="ca-cert",
+        variable="ca_cert",
         required=required,
         setting_name="ca.cert",
         settings=settings,
     )
     ca_key_path = _get_config_value(
         arguments,
-        variable="ca-key",
+        variable="ca_key",
         required=required,
         setting_name="ca.key",
         settings=settings,
@@ -259,7 +259,7 @@ def get_lifetime_short(
     """Returns the default lifetime for certs in hours"""
     return _get_config_value(
         arguments,
-        variable="life-short",
+        variable="life_short",
         required=required,
         setting_name="lifetime.short",
         settings=settings,
@@ -273,7 +273,7 @@ def get_lifetime_long(
     """Returns the long term certs lifetime in hours"""
     return _get_config_value(
         arguments,
-        variable="life-long",
+        variable="life_long",
         required=required,
         setting_name="lifetime.long",
         settings=settings,

--- a/caramel/config.py
+++ b/caramel/config.py
@@ -303,9 +303,11 @@ def setup_logging(config_path=None):
         dictConfig(DEFAULT_LOGGING_CONFIG)
 
 
-def bootstrap(config_path=None):
+def bootstrap(config_path=None, dburl=None):
     """wrapper for pyramid.paster.bootstraper, if a config_path is not given
     then DEFAULT_APP_SETTINGS to bootstrap the app manually"""
+    if dburl:
+        os.environ["CARAMEL_DBURL"] = dburl
     if config_path:
         return paster.bootstrap(config_path)
     else:

--- a/caramel/scripts/autosign.py
+++ b/caramel/scripts/autosign.py
@@ -113,7 +113,7 @@ def main():
     setup_logging(config_path)
     config.configure_log_level(args)
 
-    env = bootstrap(config_path)
+    env = bootstrap(config_path, dburl=args.dburl)
     settings, closer = env["registry"].settings, env["closer"]
 
     db_url = config.get_db_url(args, settings)

--- a/caramel/scripts/generate_ca.py
+++ b/caramel/scripts/generate_ca.py
@@ -8,7 +8,7 @@ import os
 import OpenSSL.crypto as _crypto
 from caramel.config import (
     setup_logging,
-    bootstrap,
+    get_appsettings,
 )
 from caramel import config
 
@@ -206,20 +206,17 @@ def main():
     setup_logging(config_path)
     config.configure_log_level(args)
 
-    env = bootstrap(config_path)
-    settings, closer = env["registry"].settings, env["closer"]
+    settings = get_appsettings(config_path)
 
     try:
         ca_cert_path, ca_key_path = config.get_ca_cert_key_path(args, settings)
     except ValueError as error:
         print(error)
-        closer()
         exit()
 
     for f in ca_cert_path, ca_key_path:
         if os.path.exists(f):
             print("File already exists: {}. Refusing to corrupt.".format(f))
-            closer()
             exit()
         else:
             dname = os.path.dirname(f)

--- a/caramel/scripts/tool.py
+++ b/caramel/scripts/tool.py
@@ -199,7 +199,7 @@ def csr_resign(ca, lifetime_short, lifetime_long, backdate):
 
 def main():
     args = cmdline()
-    env = bootstrap(args.inifile)
+    env = bootstrap(args.inifile, dburl=args.dburl)
     settings, closer = env["registry"].settings, env["closer"]
     db_url = config.get_db_url(args, settings)
     engine = create_engine(db_url)


### PR DESCRIPTION
Bugfix 1: Bugfix to be able to use autosign and tools using only the commandline. If an argument is passed on the commandline it should trumph all other. So in caramel.config.bootstrap we can safely overwrite the env-var CARAMEL_DB_URL with what was passed on the commandline if there where any.

Bugfix 2: Bugfix since argparse saves hyphend argument flags with underscores instead.
example: --ca-cert becomes the property .ca_cert

Also included a "correction", to generate ca-cert/key pairs no interaction with the server is needed, so bootstrapping it is not necessary.