### PR TITLE
Extend system test to include all modes of configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ LINE := $(BOLD); echo "---------------------------------------"
 RESET_TERM := printf "\033[0m"
 BLR := $(BOLD); $(LINE); $(RESET_TERM) #Bold Line, Reset formatting
 
+# Make sure we dont use any exsisting env vars
+unexport CARAMEL_INI CARAMEL_CA_CERT CARAMEL_CA_KEY CARAMEL_DBURL CARAMEL_HOST CARAMEL_PORT CARAMEL_LOG_LEVEL
+
 #Check for python3 install and virtual environment
 $(PYTHON3):
 	@if [ -z python3 ]; then \

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ AUTOSIGN := $(VENV)/autosign
 
 # Database and CA cert and key for caramel server to use
 DB_FILE := $(VENV)/caramel.sqlite
-CA_CERT := $(VENV)/caramel.ca.cert
-CA_KEY := $(VENV)/caramel.ca.key
 DB_URL := sqlite:///$(DB_FILE)
+CA_CERT := $(VENV)/example_ca/caramel.ca.cert
+CA_KEY := $(VENV)/example_ca/caramel.ca.key
 
 # client.crt will be generated if the server correctly gives our stored CSR back
 CLIENT_CERT := $(VENV)/client.crt
@@ -50,6 +50,8 @@ $(CARAMEL_TOOL): $(PYTHON3) setup.py
 	@$(BOLD); echo "Install caramel and its dependencies in venv: $(VENV)";\
 	$(BLR);
 	$(VENV)/bin/pip3 install -e .
+	cp development.ini $(VENV)/development.ini
+	mkdir $(VENV)/example_ca
 	@$(BLR)
 
 # Create a sqlite-db configured for use with caramel

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,15 @@
 VENV := $(shell mktemp -d /tmp/caramel-test.XXXXX)
 PYTHON3 := $(VENV)/bin/python3
 
-# PIDs of background processes
-SERVER_PID := $(VENV)/server.pid
-AUTOSIGN_PID := $(VENV)/autosign.pid
+# PIDs of background processes saved at VENV/[PROGRAM]-[test].pid
+SERVER := $(VENV)/server
+AUTOSIGN := $(VENV)/autosign
 
 # Database and CA cert and key for caramel server to use
 DB_FILE := $(VENV)/caramel.sqlite
 CA_CERT := $(VENV)/caramel.ca.cert
 CA_KEY := $(VENV)/caramel.ca.key
+DB_URL := sqlite:///$(DB_FILE)
 
 # client.crt will be generated if the server correctly gives our stored CSR back
 CLIENT_CERT := $(VENV)/client.crt
@@ -40,7 +41,7 @@ $(PYTHON3):
 
 
 #Install the project via setup.py
-.PHONEY: venv-install
+.PHONY: venv-install
 venv-install: $(CARAMEL_TOOL)
 $(CARAMEL_TOOL): $(PYTHON3) setup.py
 	@$(BOLD); echo "Install caramel and its dependencies in venv: $(VENV)";\
@@ -49,40 +50,53 @@ $(CARAMEL_TOOL): $(PYTHON3) setup.py
 	@$(BLR)
 
 # Create a sqlite-db configured for use with caramel
-$(DB_FILE): $(CARAMEL_TOOL)
+.PHONY: gen-db%
+gen-db%: $(CARAMEL_TOOL)
 	@$(BOLD); echo "Create a new DB at $(DB_FILE)";\
 	$(BLR);
 	$(VENV)/bin/caramel_initialize_db
 	@$(BLR)
 
 # Generate a new CA cert and key pair
-$(CA_CERT): $(CARAMEL_TOOL)
+.PHONY: ca-cert%
+ca-cert%: $(CARAMEL_TOOL)
 	@$(BOLD); echo "Generate new CA cert and key with tests/ca_test_input.txt";\
 	$(BLR)
 	$(VENV)/bin/caramel_ca < tests/ca_test_input.txt
 	@$(BLR)
 
-# Start caramel using pserve in the background, save PID to SERVER_PID
-$(SERVER_PID): $(CA_CERT) $(DB_FILE)
+# Start caramel using pserve in the background, save PID to SERVER
+$(SERVER)-env.pid: ca-cert-env gen-db-env
 	@ $(BOLD); echo "Start new caramel server in the background, sleep 2s to \
 	give it time to start";\
 	$(BLR)
 	chmod +x scripts/caramel_launcher.sh
 	setsid ./scripts/caramel_launcher.sh $(VENV)/bin/pserve >/dev/null 2>&1 < /dev/null & \
-	echo $$! > $(SERVER_PID)
+	echo $$! > $(SERVER)-env.pid
 	sleep 2s
 	@$(BLR)
 
-# Start caramel_autosign in the background, save PID to AUTOSIGN_PID
-$(AUTOSIGN_PID): $(CARAMEL_TOOL) $(CA_CERT) $(DB_FILE)
+# Start caramel using pserve in the background, save PID to SERVER
+$(SERVER)-in%.pid: ca-cert-in% gen-db-in%
+	@ $(BOLD); echo "Start new caramel server in the background, sleep 2s to \
+	give it time to start";\
+	$(BLR)
+	setsid $(VENV)/bin/pserve $(CARAMEL_COMMAND_LINE) >/dev/null 2>&1 < /dev/null & \
+	echo $$! > $(SERVER)-in$*.pid
+	sleep 2s
+	@$(BLR)
+
+# Start caramel_autosign in the background, save PID to ENV_AUTOSIGN
+$(AUTOSIGN)%.pid: $(CARAMEL_TOOL) ca-cert% gen-db%
 	@$(BOLD);echo "Start new caramel_autosign in the background";\
 	$(BLR)
-	setsid $(VENV)/bin/caramel_autosign >/dev/null 2>&1 < /dev/null &\
-	echo $$! > $(AUTOSIGN_PID)
+	setsid $(VENV)/bin/caramel_autosign $(CARAMEL_COMMAND_LINE) >/dev/null 2>&1 < /dev/null &\
+	echo $$! > $(AUTOSIGN)$*.pid
 	@$(BLR)
 
 # Try to upload a CSR to a caramel server and then confirm our CSR was stored
-$(CLIENT_CERT): $(SERVER_PID) $(AUTOSIGN_PID)
+.PHONY: client-run%
+client-run%: $(SERVER)%.pid $(AUTOSIGN)%.pid
 	@ $(BOLD); echo "Use client-example.sh to upload our CSR, wait for it to \
 	get processed, then call it again to confirm the server stored our CSR";\
 	$(BLR)
@@ -94,33 +108,34 @@ $(CLIENT_CERT): $(SERVER_PID) $(AUTOSIGN_PID)
 
 # Basic tests that caramel can be installed and run with test data,
 # using environment variables for config
-.PHONEY: systest
-systest: export CARAMEL_INI = development.ini
-systest: export CARAMEL_DBURL = sqlite:///$(DB_FILE)
-systest: export CARAMEL_CA_CERT = $(CA_CERT)
-systest: export CARAMEL_CA_KEY = $(CA_KEY)
-systest: export CARAMEL_CA = 127.0.0.1:6543
-systest: export CARAMEL_LOG_LEVEL = ERROR
-systest: $(CLIENT_CERT)
-	@kill $(shell cat $(SERVER_PID));\
+.PHONY: systest-env
+systest-env: export CARAMEL_COMMAND_LINE =
+systest-env: export CARAMEL_DBURL = $(DB_URL)
+systest-env: export CARAMEL_CA_CERT = $(CA_CERT)
+systest-env: export CARAMEL_CA_KEY = $(CA_KEY)
+systest-env: export CARAMEL_HOST = 127.0.0.1
+systest-env: export CARAMEL_PORT = 6543
+systest-env: export CARAMEL_LOG_LEVEL = ERROR
+systest-%: client-run-%
+	@kill $(shell cat $(SERVER)-$*.pid);\
 	if [ $$? -eq 0 ]; then \
 		$(PASS); $(LINE);\
 		echo "Caramel server started and terminated successfully";\
 	else \
 		$(FAIL); $(LINE);\
-		echo "System test failed: Caramel server exited before termination with\
+		echo "$@ failed: Caramel server exited before termination with\
 		 exit code: $$?";\
 		exit 1;\
 	fi;
 	@$(BLR)
 
-	@kill $(shell cat $(AUTOSIGN_PID));\
+	@kill $(shell cat $(AUTOSIGN)-$*.pid);\
 	if [ $$? -eq 0 ]; then \
 		$(PASS); $(LINE);\
 		echo "Autosign server started and terminated successfully";\
 	else \
 		$(FAIL); $(LINE);\
-		echo "System test failed: Autosign server exited before terminated with\
+		echo "$@ failed: Autosign server exited before terminated with\
 		 exit code: $$?";\
 		exit 1;\
 	fi;
@@ -128,20 +143,22 @@ systest: $(CLIENT_CERT)
 
 	@if [ -f $(CLIENT_CERT) ]; then \
 		$(PASS); $(LINE);\
-		echo "System test passed: Caramel successfully registered our CSR";\
+		echo "$@ passed: Caramel successfully registered our CSR";\
 	else \
 		$(FAIL); $(LINE);\
-		echo "System test failed: Something went wrong when communicating with \
+		echo "$@ failed: Something went wrong when communicating with \
 		the server";\
 		exit 1;\
 	fi;\
 	$(BLR)
+	@ echo "Move test data after successfull run"
+	mkdir $(VENV)/$@
+	mv -t $(VENV)/$@ $(CLIENT_CERT) $(DB_FILE) $(CA_CERT) $(CA_KEY) 
 
 
 # Removes the virtual environment created via this makefile,
-# NOTE: since venv is a temporary directory, this will only remove files if
-# 		run after a target, e.g. "make systest clean"
-.PHONEY: clean
+# NOTE: this will remove all previous virtual environments
+.PHONY: clean
 clean:
 	@echo "Removing local test virtual environment"; $(BLR)
 	rm -rf $(VENV)


### PR DESCRIPTION
Previously only configuration via setting of environment variables was tested, but since caramel now supports almost full configuration using the command line and/or environment variables new tests have been added to increase coverage. 

Based on #76 

