### PR TITLE
Nail SQLAlchemy down and dont swallow some useful exceptions

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,7 +72,7 @@ caramel:mypy:
   when: always
   image: ${PYTHON_IMAGE}
   before_script:
-    - pip3 install mypy "sqlalchemy[mypy]"
+    - python3 -m pip install mypy "sqlalchemy[mypy]<2"
   script:
     - mypy --install-types --non-interactive --config-file=setup.cfg caramel/ tests/
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,6 +18,8 @@ workflow:
     - if: $CI_EXTERNAL_PULL_REQUEST_IID
     - if: $CI_COMMIT_TAG
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    - if: $CI_COMMIT_BRANCH
+
 
 stages:
   - test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,7 @@ caramel:test:
   stage: test
   image: ${PYTHON_IMAGE}
   before_script:
-    - pip3 install .
+    - python3 -m pip install .
   script:
     - python3 -W error::DeprecationWarning -m unittest discover
 
@@ -37,7 +37,7 @@ caramel:systest:
   stage: test
   image: ${BUILD_IMAGE}
   before_script:
-    - pip3 install .
+    - python3 -m pip install .
   script:
     - make systest
 
@@ -47,9 +47,9 @@ rebase:test:
   needs:
     - caramel:test
   script:
-    - pip3 install .
+    - python3 -m pip install .
     - git every
-      -x 'pip3 install --editable .'
+      -x 'python3 -m pip install --editable .'
       -x 'flake8 caramel/ tests/'
       -x 'black --check caramel/ tests/'
 
@@ -57,7 +57,7 @@ caramel:black:
   stage: test
   image: ${PYTHON_IMAGE}
   before_script:
-    - pip3 install black
+    - python3 -m pip install black
   script:
     - black --check --diff caramel/ tests/
 
@@ -65,7 +65,7 @@ caramel:flake:
   stage: test
   image: ${PYTHON_IMAGE}
   before_script:
-    - pip3 install flake8
+    - python3 -m pip install flake8
   script:
     - flake8 caramel/ tests/
 
@@ -83,7 +83,7 @@ caramel:pylint:
   when: always
   image: ${PYTHON_IMAGE}
   before_script:
-    - pip3 install pylint pylint-exit
+    - python3 -m pip install pylint pylint-exit
     - python3 setup.py develop
   script:
       - pylint --rcfile=setup.cfg caramel/ tests/ || pylint-exit --error-fail $?
@@ -98,6 +98,6 @@ rebase:check:
     - python3 -m pip install black flake8
     # Always install "." first to track possible dependency changes
     - git every
-      -x 'pip3 install --editable .'
+      -x 'python3 -m pip install --editable .'
       -x 'flake8 caramel/ tests/'
       -x 'black --check caramel/ tests/'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,6 +38,7 @@ caramel:systest:
   image: ${BUILD_IMAGE}
   before_script:
     - python3 -m pip install .
+    - dnf -y install openssl
   script:
     - make systest
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,6 +45,7 @@ caramel:systest:
   before_script:
     - python3 -m pip install .
     - dnf -y install openssl
+    - test -e /etc/machine-id || echo f26871a049f84136bb011f4744cde2dd > /etc/machine-id
   script:
     - make systest
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,6 +31,12 @@ caramel:test:
   before_script:
     - python3 -m pip install .
   script:
+    - python3 -m unittest discover
+
+caramel:test:deprecation:
+  extends: caramel:test
+  allow_failure: true
+  script:
     - python3 -W error::DeprecationWarning -m unittest discover
 
 caramel:systest:

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ venv-install: $(CARAMEL_TOOL)
 $(CARAMEL_TOOL): $(PYTHON3) setup.py
 	@$(BOLD); echo "Install caramel and its dependencies in venv: $(VENV)";\
 	$(BLR);
-	$(VENV)/bin/pip3 install -e .
+	$(VENV)/bin/python3 -m pip install -e .
 	cp development.ini $(VENV)/development.ini
 	mkdir $(VENV)/example_ca
 	@$(BLR)

--- a/caramel/__init__.py
+++ b/caramel/__init__.py
@@ -2,8 +2,8 @@
 # vim: expandtab shiftwidth=4 softtabstop=4 tabstop=17 filetype=python :
 from pyramid.config import Configurator
 from sqlalchemy import engine_from_config
-from .config import get_db_url
 
+from .config import get_db_url
 from .models import (
     init_session,
 )

--- a/caramel/config.py
+++ b/caramel/config.py
@@ -1,12 +1,13 @@
 #! /usr/bin/env python
 # vim: expandtab shiftwidth=4 softtabstop=4 tabstop=17 filetype=python :
 """caramel.config is a helper library that standardizes and collects the logic
- in one place used by the caramel CLI tools/scripts"""
+in one place used by the caramel CLI tools/scripts"""
 
 import argparse
 import logging
-from logging.config import dictConfig
 import os
+from logging.config import dictConfig
+
 import pyramid.paster as paster
 from pyramid.scripting import prepare
 
@@ -221,7 +222,7 @@ def get_log_level(argument_level, logger=None, env=None):
         logger = logging.getLogger()
     current_level = logger.level
 
-    argument_verbosity = logging.ERROR - argument_level * 10    # level steps are 10
+    argument_verbosity = logging.ERROR - argument_level * 10  # level steps are 10
     verbosity = min(argument_verbosity, env_level, current_level)
     log_level = (
         verbosity if logging.DEBUG <= verbosity <= logging.ERROR else logging.ERROR

--- a/caramel/models.py
+++ b/caramel/models.py
@@ -22,17 +22,6 @@ HASH = {1024: "sha1", 2048: "sha256", 4096: "sha512"}
 CA_SUBJ_MATCH = (b"C", b"ST", b"L", b"O")
 
 
-def _crypto_patch():
-    """hijack _crypto internal lib and violate the default text encoding.
-    https://github.com/pyca/pyopenssl/pull/115 has a pull&fix for it
-    https://github.com/pyca/pyopenssl/issues/129 is an open issue
-    about it."""
-    _crypto._lib.ASN1_STRING_set_default_mask_asc(b"utf8only")
-
-
-_crypto_patch()
-
-
 class SigningCert(object):
     """Data class to wrap signing key + cert, to help refactoring"""
 

--- a/caramel/models.py
+++ b/caramel/models.py
@@ -1,20 +1,17 @@
 #! /usr/bin/env python
 # vim: expandtab shiftwidth=4 softtabstop=4 tabstop=17 filetype=python :
 
-import sqlalchemy as _sa
-from sqlalchemy.ext.declarative import (
-    declared_attr,
-    as_declarative
-)
-import sqlalchemy.orm as _orm
-from zope.sqlalchemy import register
-
-import OpenSSL.crypto as _crypto
-from pyramid.decorator import reify as _reify
 import datetime as _datetime
-import dateutil.parser
 import uuid
 from typing import List
+
+import dateutil.parser
+import OpenSSL.crypto as _crypto
+import sqlalchemy as _sa
+import sqlalchemy.orm as _orm
+from pyramid.decorator import reify as _reify
+from sqlalchemy.ext.declarative import as_declarative, declared_attr
+from zope.sqlalchemy import register
 
 X509_V3 = 0x2  # RFC 2459, 4.1.2.1
 
@@ -92,7 +89,7 @@ register(DBSession)
 class Base(object):
     @declared_attr  # type: ignore
     def __tablename__(cls) -> str:  # pylint: disable=no-self-argument
-        return cls.__name__.lower() # pylint: disable=no-member
+        return cls.__name__.lower()  # pylint: disable=no-member
 
     id = _sa.Column(_sa.Integer, primary_key=True)
 

--- a/caramel/scripts/autosign.py
+++ b/caramel/scripts/autosign.py
@@ -23,24 +23,22 @@ shouldn't have your private key accessible by the web-application.
 it."""
 
 import argparse
-
-import transaction
-import sys
-import logging
+import concurrent.futures
 import datetime
+import logging
+import sys
 import time
 import uuid
-import concurrent.futures
 
-from caramel.config import (
-    setup_logging,
-    bootstrap,
-)
-
+import transaction
 from sqlalchemy import create_engine
 
 import caramel.models as models
 from caramel import config
+from caramel.config import (
+    bootstrap,
+    setup_logging,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/caramel/scripts/generate_ca.py
+++ b/caramel/scripts/generate_ca.py
@@ -14,6 +14,7 @@ from caramel.config import (
     setup_logging,
 )
 
+REQ_VERSION = 0x00
 VERSION = 0x2
 CA_BITS = 4096
 # Subject attribs, in order.
@@ -123,7 +124,7 @@ def create_ca_req(subject):
     key.generate_key(_crypto.TYPE_RSA, CA_BITS)
 
     req = _crypto.X509Req()
-    req.set_version(VERSION)
+    req.set_version(REQ_VERSION)
     req.set_pubkey(key)
 
     x509subject = req.get_subject()

--- a/caramel/scripts/generate_ca.py
+++ b/caramel/scripts/generate_ca.py
@@ -30,17 +30,6 @@ CA_EXTENSIONS = [
 ]
 
 
-def _crypto_patch():
-    """hijack _crypto internal lib and violate the default text encoding.
-    https://github.com/pyca/pyopenssl/pull/115 has a pull&fix for it
-    https://github.com/pyca/pyopenssl/issues/129 is an open issue
-    about it."""
-    _crypto._lib.ASN1_STRING_set_default_mask_asc(b"utf8only")
-
-
-_crypto_patch()
-
-
 # Hack hack. :-)
 def CA_LIFE():
     d = datetime.date.today()

--- a/caramel/scripts/generate_ca.py
+++ b/caramel/scripts/generate_ca.py
@@ -1,16 +1,18 @@
-﻿#! /usr/bin/env python3
+#! /usr/bin/env python3
 # vim: expandtab shiftwidth=4 softtabstop=4 tabstop=17 filetype=python :
 
-import datetime
 import argparse
-import uuid
+import datetime
 import os
+import uuid
+
 import OpenSSL.crypto as _crypto
-from caramel.config import (
-    setup_logging,
-    get_appsettings,
-)
+
 from caramel import config
+from caramel.config import (
+    get_appsettings,
+    setup_logging,
+)
 
 VERSION = 0x2
 CA_BITS = 4096
@@ -74,7 +76,7 @@ def matching_template(x509, cacert):
     casubject = casubject[:-2]
     subject = subject[:-2]
 
-    for (ca, sub) in zip(casubject, subject):
+    for ca, sub in zip(casubject, subject):
         if ca != sub:
             raise ValueError("Subject needs to match CA cert:" "{}".format(casubject))
 

--- a/caramel/scripts/initializedb.py
+++ b/caramel/scripts/initializedb.py
@@ -3,12 +3,12 @@
 import argparse
 
 from sqlalchemy import create_engine
+
+import caramel.config as config
 from caramel.config import (
     get_appsettings,
     setup_logging,
 )
-
-import caramel.config as config
 from caramel.models import init_session
 
 

--- a/caramel/scripts/tool.py
+++ b/caramel/scripts/tool.py
@@ -2,17 +2,18 @@
 # vim: expandtab shiftwidth=4 softtabstop=4 tabstop=17 filetype=python :
 
 import argparse
-
-from caramel import config
-from caramel.config import bootstrap
-from pyramid.settings import asbool
-from sqlalchemy import create_engine
-from dateutil.relativedelta import relativedelta
-import caramel.models as models
-import transaction
+import concurrent.futures
 import datetime
 import sys
-import concurrent.futures
+
+import transaction
+from dateutil.relativedelta import relativedelta
+from pyramid.settings import asbool
+from sqlalchemy import create_engine
+
+import caramel.models as models
+from caramel import config
+from caramel.config import bootstrap
 
 
 def cmdline():

--- a/caramel/scripts/tool.py
+++ b/caramel/scripts/tool.py
@@ -185,8 +185,8 @@ def csr_resign(ca, lifetime_short, lifetime_long, backdate):
     with concurrent.futures.ThreadPoolExecutor(max_workers=16) as executor:
         try:
             csrlist = models.CSR.refreshable()
-        except Exception:
-            error_out("Not found or some other error")
+        except Exception as ex:
+            error_out(f"Not found or some other error {ex}")
         futures = (
             executor.submit(refresh, csr, ca, lifetime_short, lifetime_long, backdate)
             for csr in csrlist
@@ -194,8 +194,8 @@ def csr_resign(ca, lifetime_short, lifetime_long, backdate):
         for future in concurrent.futures.as_completed(futures):
             try:
                 future.result()
-            except Exception:
-                print("Future failed")
+            except Exception as ex:
+                print("Future failed", str(ex))
 
 
 def main():

--- a/caramel/scripts/tool.py
+++ b/caramel/scripts/tool.py
@@ -184,7 +184,7 @@ def refresh(csr, ca_cert, lifetime_short, lifetime_long, backdate):
     """Refresh a single csr."""
     last = csr.certificates.first()
     old_lifetime = last.not_after - last.not_before
-    # XXX: In a backdated cert, this is almost always true.
+    # In a backdated cert, this is almost always true.
     if old_lifetime >= lifetime_long:
         cert = models.Certificate.sign(csr, ca_cert, lifetime_long, backdate)
     else:

--- a/caramel/scripts/tool.py
+++ b/caramel/scripts/tool.py
@@ -239,8 +239,8 @@ def main():
 
     if life_short > life_long:
         error_out(
-            "Short lived certs ({0}) shouldn't last longer "
-            "than long lived certs ({1})".format(life_short, life_long)
+            f"Short lived certs ({life_short}) shouldn't last longer "
+            f"than long lived certs ({life_long})"
         )
     if args.list:
         print_list()

--- a/caramel/scripts/tool.py
+++ b/caramel/scripts/tool.py
@@ -199,7 +199,7 @@ def csr_resign(ca_cert, lifetime_short, lifetime_long, backdate):
     with concurrent.futures.ThreadPoolExecutor(max_workers=16) as executor:
         try:
             csrlist = models.CSR.refreshable()
-        except Exception as exc:
+        except Exception as exc:  # pylint:disable=broad-except
             error_out("Not found or some other error", exc=exc)
         futures = (
             executor.submit(
@@ -210,8 +210,8 @@ def csr_resign(ca_cert, lifetime_short, lifetime_long, backdate):
         for future in concurrent.futures.as_completed(futures):
             try:
                 future.result()
-            except Exception as ex:
-                LOG.error("Future failed: %s", ex)
+            except Exception as exc:  # pylint:disable=broad-except
+                LOG.error("Future failed: %s", exc)
 
 
 def main():

--- a/caramel/scripts/tool.py
+++ b/caramel/scripts/tool.py
@@ -80,8 +80,10 @@ def cmdline():
     return args
 
 
-def error_out(message):
+def error_out(message, exc=None):
     print(message)
+    if exc is not None:
+        print(str(exc))
     sys.exit(1)
 
 
@@ -185,8 +187,8 @@ def csr_resign(ca, lifetime_short, lifetime_long, backdate):
     with concurrent.futures.ThreadPoolExecutor(max_workers=16) as executor:
         try:
             csrlist = models.CSR.refreshable()
-        except Exception as ex:
-            error_out(f"Not found or some other error {ex}")
+        except Exception as exc:
+            error_out("Not found or some other error", exc=exc)
         futures = (
             executor.submit(refresh, csr, ca, lifetime_short, lifetime_long, backdate)
             for csr in csrlist
@@ -216,7 +218,7 @@ def main():
     try:
         ca_cert_path, ca_key_path = config.get_ca_cert_key_path(args, settings)
     except ValueError as error:
-        error_out(str(error))
+        error_out("Error reading ca data", exc=error)
 
     ca = models.SigningCert.from_files(ca_cert_path, ca_key_path)
 

--- a/caramel/scripts/tool.py
+++ b/caramel/scripts/tool.py
@@ -1,5 +1,6 @@
 #!/bin/env python3
 # vim: expandtab shiftwidth=4 softtabstop=4 tabstop=17 filetype=python :
+"""Admin tool to sign/refresh certificates."""
 
 import argparse
 import concurrent.futures
@@ -18,6 +19,7 @@ LOG = logging.getLogger(name="caramel.tool")
 
 
 def cmdline():
+    """Parse commandline."""
     parser = argparse.ArgumentParser()
 
     config.add_inifile_argument(parser)
@@ -82,6 +84,7 @@ def cmdline():
 
 
 def error_out(message, exc=None):
+    """Print error message and exit with failure code."""
     LOG.error(message)
     if exc is not None:
         LOG.error(str(exc))
@@ -89,6 +92,7 @@ def error_out(message, exc=None):
 
 
 def print_list():
+    """Print a list of certificates."""
     valid_requests = models.CSR.list_csr_printable()
 
     def unsigned_last(csr):
@@ -104,12 +108,14 @@ def print_list():
 
 
 def calc_lifetime(lifetime=relativedelta(hours=24)):
+    """Calculate lifetime of certificate."""
     now = datetime.datetime.utcnow()
     future = now + lifetime
     return future - now
 
 
 def csr_wipe(csr_id):
+    """Wipe a certain csr."""
     with transaction.manager:
         CSR = models.CSR.query().get(csr_id)
         if not CSR:
@@ -119,6 +125,7 @@ def csr_wipe(csr_id):
 
 
 def csr_clean(csr_id):
+    """Clean out old certs."""
     with transaction.manager:
         CSR = models.CSR.query().get(csr_id)
         if not CSR:
@@ -129,12 +136,14 @@ def csr_clean(csr_id):
 
 
 def clean_all():
+    """Clean out all old requests."""
     csrlist = models.CSR.refreshable()
     for csr in csrlist:
         csr_clean(csr.id)
 
 
 def csr_reject(csr_id):
+    """Reject a request."""
     with transaction.manager:
         CSR = models.CSR.query().get(csr_id)
         if not CSR:
@@ -145,6 +154,7 @@ def csr_reject(csr_id):
 
 
 def csr_sign(csr_id, ca, timedelta, backdate):
+    """Sign a request with ca, valid for timedelta, or backdate as well."""
     with transaction.manager:
         CSR = models.CSR.query().get(csr_id)
         if not CSR:
@@ -172,6 +182,7 @@ def csr_sign(csr_id, ca, timedelta, backdate):
 
 
 def refresh(csr, ca, lifetime_short, lifetime_long, backdate):
+    """Refresh a single csr."""
     last = csr.certificates.first()
     old_lifetime = last.not_after - last.not_before
     # XXX: In a backdated cert, this is almost always true.
@@ -185,6 +196,7 @@ def refresh(csr, ca, lifetime_short, lifetime_long, backdate):
 
 
 def csr_resign(ca, lifetime_short, lifetime_long, backdate):
+    """Re-sign all requests for lifetime."""
     with concurrent.futures.ThreadPoolExecutor(max_workers=16) as executor:
         try:
             csrlist = models.CSR.refreshable()

--- a/caramel/views.py
+++ b/caramel/views.py
@@ -1,19 +1,18 @@
 #! /usr/bin/env python
 # vim: expandtab shiftwidth=4 softtabstop=4 tabstop=17 filetype=python :
-from hashlib import sha256
 from datetime import datetime
+from hashlib import sha256
 
+from pyramid.httpexceptions import (
+    HTTPBadRequest,
+    HTTPError,
+    HTTPForbidden,
+    HTTPLengthRequired,
+    HTTPNotFound,
+    HTTPRequestEntityTooLarge,
+)
 from pyramid.response import Response
 from pyramid.view import view_config
-from pyramid.httpexceptions import (
-    HTTPLengthRequired,
-    HTTPRequestEntityTooLarge,
-    HTTPBadRequest,
-    HTTPNotFound,
-    HTTPForbidden,
-    HTTPError,
-)
-
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -23,12 +22,11 @@ from .models import (
     SigningCert,
 )
 
-
 # Maximum length allowed for csr uploads.
 # 2 kbyte should be enough for up to 4 kbit keys.
 # XXX: This should probably be handled outside of app (i.e. by the
 #      server), or at least be configurable.
-_MAXLEN = 2 * 2 ** 10
+_MAXLEN = 2 * 2**10
 
 
 def raise_for_length(req, limit=_MAXLEN):
@@ -38,7 +36,7 @@ def raise_for_length(req, limit=_MAXLEN):
     if length is None:
         raise HTTPLengthRequired
     if length > limit:
-        raise HTTPRequestEntityTooLarge("Max size: {0} kB".format(limit / 2 ** 10))
+        raise HTTPRequestEntityTooLarge("Max size: {0} kB".format(limit / 2**10))
 
 
 def raise_for_subject(components, required_prefix):

--- a/scripts/caramel_launcher.sh
+++ b/scripts/caramel_launcher.sh
@@ -4,9 +4,9 @@
 SCRIPT_HOME="$(dirname "$(realpath "$0")")"
 
 if [ -z "$1" ]; then
-  PSERVE=$1
-else
   PSERVE=pserve
+else
+  PSERVE=$1
 fi
 
 exec $PSERVE "${SCRIPT_HOME}/caramel_launcher.ini" \

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 requires = [
     "pyramid",
-    "SQLAlchemy >= 1.4",
+    "SQLAlchemy ~= 1.4.32",
     "transaction",
     "pyramid_tm",
     "zope.sqlalchemy >= 1.3",
@@ -16,7 +16,7 @@ deplinks = []
 
 setup(
     name="caramel",
-    version="1.9.2",
+    version="1.9.3",
     python_requires=">=3.6",
     description="caramel",
     long_description="""

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,8 @@ deplinks = []
 
 setup(
     name="caramel",
-    version="1.9.3",
-    python_requires=">=3.6",
+    version="1.9.5",
+    python_requires=">=3.7",
     description="caramel",
     long_description="""
 Caramel is a certificate management system that makes it easy to use client

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,10 @@ requires = [
     "SQLAlchemy ~= 1.4.32",
     "transaction",
     "pyramid_tm",
-    "zope.sqlalchemy >= 1.3",
+    "zope.sqlalchemy >= 1.6",
     "waitress",
-    "cryptography>=0.5.dev1",
-    "pyOpenSSL>=0.14",
+    "cryptography >= 38",
+    "pyOpenSSL >= 22.0.0",
     "python-dateutil",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,9 @@ requires = [
     "cryptography >= 38",
     "pyOpenSSL >= 22.0.0",
     "python-dateutil",
+    # Transient dependency from pyramid->webob,
+    # should be fixed in a later release of webob
+    "legacy-cgi; python_version >= '3.13'"
 ]
 
 deplinks = []

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,8 +6,8 @@ from itertools import zip_longest
 import transaction
 
 from caramel.models import (
-    init_session,
     DBSession,
+    init_session,
 )
 
 from . import fixtures

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,10 +1,10 @@
 #! /usr/bin/env python
 # vim: expandtab shiftwidth=4 softtabstop=4 tabstop=17 filetype=python :
-from textwrap import dedent
-from hashlib import sha256
-from operator import attrgetter
 from datetime import datetime, timedelta
+from hashlib import sha256
 from itertools import zip_longest
+from operator import attrgetter
+from textwrap import dedent
 
 from caramel import models, views
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,8 +2,8 @@
 # vim: expandtab shiftwidth=4 softtabstop=4 tabstop=17 filetype=python :
 """tests.test_config contains the unittests for caramel.config"""
 import argparse
-import unittest
 import logging
+import unittest
 
 from caramel import config
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,17 +2,17 @@
 # vim: expandtab shiftwidth=4 softtabstop=4 tabstop=17 filetype=python :
 
 import unittest
+from operator import attrgetter
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm.exc import NoResultFound
 
 from caramel.models import (
     CSR,
     SigningCert,
 )
 
-from . import fixtures, ModelTestCase
-
-from operator import attrgetter
-from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm.exc import NoResultFound
+from . import ModelTestCase, fixtures
 
 
 class TestCSR(ModelTestCase):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -5,22 +5,21 @@ import unittest
 import unittest.mock
 
 from pyramid import testing
-from pyramid.response import Response
 from pyramid.httpexceptions import (
-    HTTPLengthRequired,
-    HTTPRequestEntityTooLarge,
     HTTPBadRequest,
+    HTTPLengthRequired,
     HTTPNotFound,
+    HTTPRequestEntityTooLarge,
 )
+from pyramid.response import Response
 
-
+from caramel import views
 from caramel.models import (
     CSR,
     AccessLog,
 )
-from caramel import views
 
-from . import fixtures, ModelTestCase
+from . import ModelTestCase, fixtures
 
 
 def dummypost(fix, **args):


### PR DESCRIPTION
Turns out the tool swallows the output of exceptions in a rather bad way, and I should fix that, but not now.

And the SQLalchemy 2.0 release showed up and turned this into a party.
